### PR TITLE
docs(asr): complete, paper-grounded example gallery (5 -> 13)

### DIFF
--- a/examples/asr/README.rst
+++ b/examples/asr/README.rst
@@ -1,27 +1,50 @@
 ASR Examples
 ============
 
-Examples demonstrating Artifact Subspace Reconstruction for burst-artifact
-repair in EEG data.
+Examples demonstrating Artifact Subspace Reconstruction (ASR) for burst-artifact
+repair in EEG (and MEG) data --- from a basic clean to a full preprocessing
+pipeline, with each method example grounded in its source paper.
 
-Files
------
+Getting started
+---------------
 
-- ``plot_01_basic_usage.py``: Standard ASR on synthetic multichannel burst
-  artifacts.
-- ``plot_02_mne_raw_qc.py``: MNE ``Raw`` usage with repair annotations and
-  optional final clean_windows-style rejection masks.
-- ``plot_03_adaptive_asr.py``: AASR-style adaptive chunk updates with
-  ``partial_fit()`` then ``transform()``.
-- ``plot_04_juggler_asr.py``: Juggler-style DBSCAN calibration on dense short
-  bursts.
-- ``plot_05_asr_visualization.py``: The ``mne_denoise.viz`` ASR plotting
-  helpers — overlay, cutoff sweep, variance topography, repair timeline, and a
-  standard-vs-Riemannian method comparison.
+- ``plot_01_asr_basics.py``: Standard ASR on synthetic multichannel bursts.
+- ``plot_02_mne_raw_qc.py``: MNE ``Raw`` usage with repair annotations and an
+  optional clean_windows-style final rejection mask.
+- ``plot_05_asr_visualization.py``: The ASR-specific ``mne_denoise.viz`` plots
+  (repair timeline, component reconstruction, calibration fraction) alongside the
+  generic before/after and PSD helpers.
+
+Cutoff and variants
+-------------------
+
+- ``plot_06_cutoff_tuning.py``: How ``cutoff`` trades data modified against
+  variance removed (Chang 2020).
+- ``plot_07_riemannian_asr.py``: Riemannian (``method="riemannian_windowed"``)
+  vs standard ASR on real blinks (Blum 2019).
+- ``plot_03_adaptive_asr.py``: AASR-style streaming with ``fit`` /
+  ``partial_fit`` / ``transform``.
+- ``plot_08_adaptive_variants.py``: Adaptive ``psp`` vs ``psw`` vs ``mw`` on
+  non-stationary data, with the moving-window adaptation trajectory (Tsai).
+- ``plot_04_juggler_asr.py``: Juggler DBSCAN calibration on dense short bursts.
+- ``plot_09_juggler_strategies.py``: Juggler ``dbscan`` vs ``gev`` reference
+  selection under heavy contamination (Kim 2025).
+- ``plot_10_choosing_a_variant.py``: Standard vs Riemannian vs Juggler on one
+  substrate, with a short recommendation.
+
+I/O, QC, and pipelines
+----------------------
+
+- ``plot_11_epochs_and_meg.py``: ASR on ``mne.Epochs`` and on MEG magnetometers.
+- ``plot_12_diagnostics_qc.py``: ``get_diagnostics`` / ``compute_asr_qa_metrics``
+  / ``to_annotations`` and the three ASR diagnostic plots.
+- ``plot_13_pipeline_filter_asr_ica.py``: A realistic ``filter -> ASR -> ICA``
+  workflow on real EEG.
 
 Notes
 -----
 
-The examples use synthetic data so they can run without external downloads.
-Apply ASR to real EEG only after bad-channel handling, referencing decisions,
-and high-pass filtering have been made in the surrounding MNE workflow.
+Most examples use synthetic data so they run without downloads; ``plot_07`` and
+``plot_13`` (and the MEG part of ``plot_11``) use the MNE *sample* dataset.
+Apply ASR to real EEG only after bad-channel handling, referencing, and
+high-pass filtering in the surrounding MNE workflow.

--- a/examples/asr/plot_06_cutoff_tuning.py
+++ b/examples/asr/plot_06_cutoff_tuning.py
@@ -1,0 +1,96 @@
+r"""
+Choosing the ASR cutoff.
+========================
+
+The ASR ``cutoff`` (standard-deviation threshold) is the single most important
+knob: lower values clean aggressively (and risk removing real high-variance
+brain activity), higher values are conservative. This example sweeps the cutoff
+and plots the two quantities Chang et al. (2020) use to characterise it --- the
+fraction of data modified and the variance removed --- reproducing the monotone
+trade-off of their Figs 2-3 and the commonly recommended 20-30 band.
+
+References
+----------
+.. [1] Chang, C.-Y., Hsu, S.-H., Pion-Tonachini, L., & Jung, T.-P. (2020).
+   Evaluation of Artifact Subspace Reconstruction for Automatic Artifact
+   Components Removal in Multi-Channel EEG Recordings. IEEE Transactions on
+   Biomedical Engineering, 67(4), 1114-1121. doi:10.1109/TBME.2019.2930186
+.. [2] Mullen, T. R., et al. (2013). Real-time modeling and 3D visualization of
+   source dynamics and connectivity using wearable EEG. EMBC 2013.
+   doi:10.1109/EMBC.2013.6609968
+"""
+
+# %%
+# Imports and synthetic data
+# --------------------------
+# Oscillatory "brain" background plus spatially-structured high-amplitude bursts.
+import matplotlib.pyplot as plt
+import numpy as np
+
+from mne_denoise.asr import ASR, compute_asr_qa_metrics
+
+rng = np.random.default_rng(2024)
+sfreq = 250.0
+n_channels, n_times = 16, 12000  # 48 s
+t = np.arange(n_times) / sfreq
+
+brain = np.zeros((n_channels, n_times))
+for ch in range(n_channels):
+    phase = rng.uniform(0, 2 * np.pi)
+    brain[ch] = (
+        0.6 * np.sin(2 * np.pi * 10.0 * t + phase)
+        + 0.15 * np.sin(2 * np.pi * 6.0 * t + 0.7 * phase)
+        + 0.05 * rng.standard_normal(n_times)
+    )
+
+contaminated = brain.copy()
+# Graded burst severities (1.5x -> 9x): aggressive cutoffs remove even the mild
+# bursts, conservative cutoffs only the strongest -> both metrics vary with cutoff.
+starts = np.linspace(800, n_times - 700, 12).astype(int)
+amplitudes = np.linspace(1.5, 9.0, len(starts))
+for start, amp in zip(starts, amplitudes):
+    spatial = rng.standard_normal(n_channels)
+    spatial /= np.linalg.norm(spatial)
+    contaminated[:, start : start + 250] += amp * np.outer(
+        spatial, rng.standard_normal(250)
+    )
+
+# %%
+# Sweep the cutoff
+# ----------------
+# For each cutoff, fit + transform and read the two headline metrics straight
+# from :func:`~mne_denoise.asr.compute_asr_qa_metrics`.
+cutoffs = [1, 5, 10, 20, 30, 50, 100]
+pct_modified, pct_var_removed = [], []
+for k in cutoffs:
+    asr = ASR(sfreq=sfreq, cutoff=float(k), picks=None, verbose=False)
+    cleaned = np.asarray(asr.fit_transform(contaminated))
+    metrics = compute_asr_qa_metrics(contaminated, cleaned, asr)
+    pct_modified.append(100.0 * metrics["fraction_reconstructed_samples"])
+    pct_var_removed.append(metrics["variance_removed_pct"])
+    print(
+        f"cutoff={k:3d}:  data modified={pct_modified[-1]:5.1f}%   "
+        f"variance removed={pct_var_removed[-1]:5.1f}%"
+    )
+
+# %%
+# Plot the trade-off
+# ------------------
+# Both curves decrease monotonically with cutoff: aggressive (low) cutoffs touch
+# more data and strip more variance; conservative (high) cutoffs do little.
+fig, ax1 = plt.subplots(figsize=(8, 5))
+ax2 = ax1.twinx()
+ax1.axvspan(20, 30, color="0.88", zorder=0, label="recommended (20-30)")
+(l1,) = ax1.plot(cutoffs, pct_modified, "o-", color="C3", label="% data modified")
+(l2,) = ax2.plot(cutoffs, pct_var_removed, "s-", color="C0", label="% variance removed")
+ax1.set_xscale("log")
+ax1.set_xticks(cutoffs)
+ax1.set_xticklabels([str(c) for c in cutoffs])
+ax1.set_xlabel("ASR cutoff (standard-deviation threshold)")
+ax1.set_ylabel("% data modified", color="C3")
+ax2.set_ylabel("% variance removed", color="C0")
+ax1.set_title("ASR cutoff trade-off (cf. Chang 2020, Figs 2-3)")
+ax1.legend(handles=[l1, l2, ax1.patches[0]], loc="upper right")
+fig.tight_layout()
+
+plt.show()

--- a/examples/asr/plot_06_cutoff_tuning.py
+++ b/examples/asr/plot_06_cutoff_tuning.py
@@ -11,13 +11,13 @@ trade-off of their Figs 2-3 and the commonly recommended 20-30 band.
 
 References
 ----------
-.. [1] Chang, C.-Y., Hsu, S.-H., Pion-Tonachini, L., & Jung, T.-P. (2020).
-   Evaluation of Artifact Subspace Reconstruction for Automatic Artifact
-   Components Removal in Multi-Channel EEG Recordings. IEEE Transactions on
-   Biomedical Engineering, 67(4), 1114-1121. doi:10.1109/TBME.2019.2930186
-.. [2] Mullen, T. R., et al. (2013). Real-time modeling and 3D visualization of
-   source dynamics and connectivity using wearable EEG. EMBC 2013.
-   doi:10.1109/EMBC.2013.6609968
+* Chang, C.-Y., Hsu, S.-H., Pion-Tonachini, L., & Jung, T.-P. (2020).
+  Evaluation of Artifact Subspace Reconstruction for Automatic Artifact
+  Components Removal in Multi-Channel EEG Recordings. IEEE Transactions on
+  Biomedical Engineering, 67(4), 1114-1121. doi:10.1109/TBME.2019.2930186
+* Mullen, T. R., et al. (2013). Real-time modeling and 3D visualization of
+  source dynamics and connectivity using wearable EEG. EMBC 2013.
+  doi:10.1109/EMBC.2013.6609968
 """
 
 # %%

--- a/examples/asr/plot_07_riemannian_asr.py
+++ b/examples/asr/plot_07_riemannian_asr.py
@@ -1,0 +1,115 @@
+r"""
+Riemannian ASR versus standard ASR.
+===================================
+
+Blum et al. (2019) replace ASR's sample-covariance calibration with a
+**Riemannian geometric median**, making the clean-covariance estimate robust to
+the occasional contaminated calibration window. ``mne-denoise`` exposes this as
+``method="riemannian_windowed"`` --- it keeps the Riemannian robust calibration
+but applies a standard per-window eigendecomposition at processing time, so
+(unlike the MATLAB-parity ``method="riemannian"``) the ``cutoff`` knob still
+works.
+
+This example runs both backends on real EEG with eye blinks (the MNE *sample*
+dataset) and compares frontal blink removal (cf. Blum 2019, Fig. 3). On this
+relatively clean recording the two are comparable; rASR's documented edge ---
+robustness when the calibration windows themselves are contaminated --- is by
+design and is not stressed here.
+
+References
+----------
+.. [1] Blum, S., Jacobsen, N. S. J., Bleichner, M. G., & Debener, S. (2019).
+   A Riemannian Modification of Artifact Subspace Reconstruction for EEG
+   Artifact Handling. Frontiers in Human Neuroscience, 13, 141.
+   doi:10.3389/fnhum.2019.00141
+.. [2] Chang, C.-Y., et al. (2020). Evaluation of Artifact Subspace
+   Reconstruction... IEEE TBME, 67(4), 1114-1121. doi:10.1109/TBME.2019.2930186
+"""
+
+# %%
+# Load real EEG with eye blinks
+# -----------------------------
+import matplotlib.pyplot as plt
+import mne
+import numpy as np
+
+from mne_denoise.asr import ASR
+from mne_denoise.viz import plot_signal_overlay
+
+sample = mne.datasets.sample.data_path()
+raw = mne.io.read_raw_fif(
+    sample / "MEG" / "sample" / "sample_audvis_raw.fif",
+    preload=True,
+    verbose="ERROR",
+)
+raw.pick(["eeg", "eog"]).crop(0, 60).resample(160, verbose="ERROR")
+raw.set_eeg_reference("average", verbose="ERROR")
+raw.filter(1.0, None, verbose="ERROR")  # ASR assumes high-pass-filtered data
+
+# %%
+# Find the blink-dominated EEG channel
+# ------------------------------------
+# The channel most correlated with the EOG carries the strongest blinks.
+eeg_names = [raw.ch_names[i] for i in mne.pick_types(raw.info, eeg=True)]
+eeg = raw.get_data(picks="eeg")
+eog = raw.get_data(picks="eog")[0]
+corr = np.array([abs(np.corrcoef(ch, eog)[0, 1]) for ch in eeg])
+blink_ch = eeg_names[int(np.argmax(corr))]
+print(f"Most blink-correlated EEG channel: {blink_ch} (|r|={corr.max():.2f})")
+
+# %%
+# Clean with standard and Riemannian-windowed ASR
+# -----------------------------------------------
+asr_std = ASR(cutoff=20.0, picks="eeg", method="standard", verbose=False)
+clean_std = asr_std.fit_transform(raw.copy())
+
+asr_rie = ASR(cutoff=20.0, picks="eeg", method="riemannian_windowed", verbose=False)
+clean_rie = asr_rie.fit_transform(raw.copy())
+
+# %%
+# Before/after on the blink channel (Riemannian-windowed)
+# -------------------------------------------------------
+plot_signal_overlay(
+    raw,
+    clean_rie,
+    raw.times,
+    pick=blink_ch,
+    scale_after=False,
+    before_label="raw",
+    after_label="rASR-cleaned",
+    x_label="Time (s)",
+    y_label="Amplitude (V)",
+    title=f"Riemannian-windowed ASR on {blink_ch}",
+    show=False,
+)
+
+# %%
+# Blink removal: decoupling the frontal EEG from the EOG (cf. Blum 2019, Fig. 3)
+# -----------------------------------------------------------------------------
+# A blink-specific score: mean absolute correlation between the 8 most
+# blink-correlated EEG channels and the EOG, before vs after cleaning (lower is
+# better). Both backends collapse it from ~0.65 to <0.1 --- comparable here,
+# standard marginally more aggressive.
+top = np.argsort(corr)[-8:]
+
+
+def mean_eog_coupling(data_eeg):
+    return float(np.mean([abs(np.corrcoef(ch, eog)[0, 1]) for ch in data_eeg[top]]))
+
+
+coupling = {
+    "raw": mean_eog_coupling(eeg),
+    "standard": mean_eog_coupling(clean_std.get_data(picks="eeg")),
+    "riemannian_windowed": mean_eog_coupling(clean_rie.get_data(picks="eeg")),
+}
+for name, value in coupling.items():
+    print(f"  {name:20s} mean |corr with EOG| = {value:.3f}")
+
+fig, ax = plt.subplots(figsize=(5.5, 4))
+ax.bar(list(coupling), list(coupling.values()), color=["C3", "0.6", "C0"])
+ax.set_ylabel("mean |corr with EOG| (8 frontal channels)")
+ax.set_title("Blink coupling before / after ASR (lower = blinks removed)")
+ax.tick_params(axis="x", labelrotation=15)
+fig.tight_layout()
+
+plt.show()

--- a/examples/asr/plot_07_riemannian_asr.py
+++ b/examples/asr/plot_07_riemannian_asr.py
@@ -18,12 +18,12 @@ design and is not stressed here.
 
 References
 ----------
-.. [1] Blum, S., Jacobsen, N. S. J., Bleichner, M. G., & Debener, S. (2019).
-   A Riemannian Modification of Artifact Subspace Reconstruction for EEG
-   Artifact Handling. Frontiers in Human Neuroscience, 13, 141.
-   doi:10.3389/fnhum.2019.00141
-.. [2] Chang, C.-Y., et al. (2020). Evaluation of Artifact Subspace
-   Reconstruction... IEEE TBME, 67(4), 1114-1121. doi:10.1109/TBME.2019.2930186
+* Blum, S., Jacobsen, N. S. J., Bleichner, M. G., & Debener, S. (2019).
+  A Riemannian Modification of Artifact Subspace Reconstruction for EEG
+  Artifact Handling. Frontiers in Human Neuroscience, 13, 141.
+  doi:10.3389/fnhum.2019.00141
+* Chang, C.-Y., et al. (2020). Evaluation of Artifact Subspace
+  Reconstruction... IEEE TBME, 67(4), 1114-1121. doi:10.1109/TBME.2019.2930186
 """
 
 # %%
@@ -85,7 +85,7 @@ plot_signal_overlay(
 
 # %%
 # Blink removal: decoupling the frontal EEG from the EOG (cf. Blum 2019, Fig. 3)
-# -----------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # A blink-specific score: mean absolute correlation between the 8 most
 # blink-correlated EEG channels and the EOG, before vs after cleaning (lower is
 # better). Both backends collapse it from ~0.65 to <0.1 --- comparable here,

--- a/examples/asr/plot_08_adaptive_variants.py
+++ b/examples/asr/plot_08_adaptive_variants.py
@@ -10,10 +10,13 @@ exposes three calibration rules via :class:`~mne_denoise.asr.AdaptiveASR`:
 - ``variant="psw"`` -- plasticity-stabilized whitening (anti-Hebbian);
 - ``variant="mw"`` -- moving-window calibration (one calibration per window).
 
-This example compares all three on a recording whose artifact statistics change
-half-way through, and plots the moving-window adaptation trajectory. (For the
-streaming ``fit`` / ``partial_fit`` / ``transform`` mechanics, see
-``plot_03_adaptive_asr.py``.)
+This example compares all three on a recording whose artifact *subspace* rotates
+continuously over time. On this cleanly-separable synthetic data the variants
+clean comparably (mw, which recalibrates every window, is marginally best); their
+differences are most pronounced on real overlapping contamination (Tsai). The
+clearest variant-specific behaviour to watch is the moving-window adaptation
+trajectory. (For the streaming ``fit`` / ``partial_fit`` / ``transform``
+mechanics, see ``plot_03_adaptive_asr.py``.)
 
 References
 ----------
@@ -27,8 +30,8 @@ References
 # %%
 # Non-stationary synthetic data
 # -----------------------------
-# Oscillatory brain background + bursts whose amplitude doubles in the second
-# half, so a static calibration is sub-optimal and adaptation matters.
+# Oscillatory brain background + bursts whose spatial direction rotates across
+# the recording, so a fixed calibration goes stale and adaptation matters.
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -38,7 +41,6 @@ rng = np.random.default_rng(11)
 sfreq = 200.0
 n_channels, n_times = 8, 9000  # 45 s
 t = np.arange(n_times) / sfreq
-half = n_times // 2
 
 brain = np.zeros((n_channels, n_times))
 for ch in range(n_channels):
@@ -48,11 +50,16 @@ for ch in range(n_channels):
     )
 
 contaminated = brain.copy()
-for start in np.arange(400, n_times - 400, 600):
-    amp = 6.0 if start < half else 12.0  # statistics shift at the midpoint
-    spatial = rng.standard_normal(n_channels)
-    spatial /= np.linalg.norm(spatial)
-    contaminated[:, start : start + 200] += amp * np.outer(
+v0 = rng.standard_normal(n_channels)
+v0 /= np.linalg.norm(v0)
+v1 = rng.standard_normal(n_channels)
+v1 -= (v1 @ v0) * v0  # orthogonalize v1 against v0
+v1 /= np.linalg.norm(v1)
+burst_starts = np.arange(400, n_times - 400, 450)
+for k, start in enumerate(burst_starts):
+    angle = (k / (len(burst_starts) - 1)) * (np.pi / 2)  # rotate v0 -> v1
+    spatial = np.cos(angle) * v0 + np.sin(angle) * v1
+    contaminated[:, start : start + 200] += 8.0 * np.outer(
         spatial, rng.standard_normal(200)
     )
 
@@ -60,11 +67,11 @@ for start in np.arange(400, n_times - 400, 600):
 # %%
 # Clean with each variant
 # -----------------------
-# PSP/PSW are streamed (fit on the first third, partial_fit the rest) so their
-# adaptive update rule is exercised; MW calibrates per window inside fit.
+# PSP/PSW are streamed (fit on the first chunk, partial_fit the rest) so their
+# adaptive update rule tracks the drift; MW recalibrates per window inside fit.
 def stream_clean(variant):
     est = AdaptiveASR(sfreq=sfreq, cutoff=20.0, variant=variant, verbose=False)
-    chunks = np.array_split(contaminated, 3, axis=1)
+    chunks = np.array_split(contaminated, 6, axis=1)
     est.fit(chunks[0])
     for chunk in chunks[1:]:
         est.partial_fit(chunk)
@@ -97,21 +104,24 @@ corrs = [scores(cleaned[v])[0] for v in variants]
 dsnrs = [scores(cleaned[v])[1] for v in variants]
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(9, 4))
-ax1.bar(variants, corrs, color="C0")
+bars1 = ax1.bar(variants, corrs, color="C0")
 ax1.set_ylim(0, 1)
+ax1.bar_label(bars1, fmt="%.3f", padding=2)
 ax1.set_ylabel("correlation to clean reference")
 ax1.set_title("Signal fidelity")
-ax2.bar(variants, dsnrs, color="C2")
+bars2 = ax2.bar(variants, dsnrs, color="C2")
+ax2.bar_label(bars2, fmt="%.1f", padding=2)
 ax2.set_ylabel("SNR gain (dB)")
 ax2.set_title("Artifact suppression")
-fig.suptitle("Adaptive ASR variants on non-stationary data")
-fig.tight_layout()
+fig.suptitle("Adaptive variants clean comparably here (mw marginally best)")
+fig.tight_layout(rect=(0, 0, 1, 0.94))
 
 # %%
 # Moving-window adaptation trajectory
 # -----------------------------------
-# How much the threshold matrix T changes from window to window: the spike near
-# the midpoint is the MW calibration tracking the artifact-statistics shift.
+# How much the threshold matrix T changes from window to window: nonzero
+# throughout, as the MW calibration keeps re-estimating while the subspace
+# rotates.
 passed = [d for d in mw.mw_diagnostics_ if d["status"] == "passed"]
 t_mats = [d["T"] for d in passed]
 deltas = [
@@ -124,11 +134,9 @@ centers = [
 
 fig2, ax = plt.subplots(figsize=(8, 4))
 ax.plot(centers, deltas, "o-", color="C3")
-ax.axvline(half / sfreq, color="0.5", ls="--", label="statistics shift")
 ax.set_xlabel("Time (s)")
 ax.set_ylabel(r"$\|T_t - T_{t-1}\|_F$")
-ax.set_title("MW-ASR adaptation trajectory")
-ax.legend()
+ax.set_title("MW-ASR adaptation trajectory (continuous re-estimation)")
 fig2.tight_layout()
 
 plt.show()

--- a/examples/asr/plot_08_adaptive_variants.py
+++ b/examples/asr/plot_08_adaptive_variants.py
@@ -17,11 +17,11 @@ streaming ``fit`` / ``partial_fit`` / ``transform`` mechanics, see
 
 References
 ----------
-.. [1] Tsai, B.-Y., et al. Adaptive Artifact Subspace Reconstruction based on
-   Hebbian/anti-Hebbian learning networks for enhancing BCI performance.
-   (AASR reference implementation.)
-.. [2] Pehlevan, C., & Chklovskii, D. B. (2019). Neuroscience-inspired online
-   unsupervised learning algorithms. IEEE Signal Processing Magazine, 36(6).
+* Tsai, B.-Y., et al. Adaptive Artifact Subspace Reconstruction based on
+  Hebbian/anti-Hebbian learning networks for enhancing BCI performance.
+  (AASR reference implementation.)
+* Pehlevan, C., & Chklovskii, D. B. (2019). Neuroscience-inspired online
+  unsupervised learning algorithms. IEEE Signal Processing Magazine, 36(6).
 """
 
 # %%

--- a/examples/asr/plot_08_adaptive_variants.py
+++ b/examples/asr/plot_08_adaptive_variants.py
@@ -1,0 +1,134 @@
+r"""
+Adaptive ASR variants (PSP / PSW / MW).
+=======================================
+
+Adaptive ASR (Tsai et al.) keeps standard ASR's burst reconstruction but lets
+the clean-subspace model **track non-stationary recordings**. ``mne-denoise``
+exposes three calibration rules via :class:`~mne_denoise.asr.AdaptiveASR`:
+
+- ``variant="psp"`` -- plasticity-stabilized (Hebbian) similarity matching;
+- ``variant="psw"`` -- plasticity-stabilized whitening (anti-Hebbian);
+- ``variant="mw"`` -- moving-window calibration (one calibration per window).
+
+This example compares all three on a recording whose artifact statistics change
+half-way through, and plots the moving-window adaptation trajectory. (For the
+streaming ``fit`` / ``partial_fit`` / ``transform`` mechanics, see
+``plot_03_adaptive_asr.py``.)
+
+References
+----------
+.. [1] Tsai, B.-Y., et al. Adaptive Artifact Subspace Reconstruction based on
+   Hebbian/anti-Hebbian learning networks for enhancing BCI performance.
+   (AASR reference implementation.)
+.. [2] Pehlevan, C., & Chklovskii, D. B. (2019). Neuroscience-inspired online
+   unsupervised learning algorithms. IEEE Signal Processing Magazine, 36(6).
+"""
+
+# %%
+# Non-stationary synthetic data
+# -----------------------------
+# Oscillatory brain background + bursts whose amplitude doubles in the second
+# half, so a static calibration is sub-optimal and adaptation matters.
+import matplotlib.pyplot as plt
+import numpy as np
+
+from mne_denoise.asr import AdaptiveASR
+
+rng = np.random.default_rng(11)
+sfreq = 200.0
+n_channels, n_times = 8, 9000  # 45 s
+t = np.arange(n_times) / sfreq
+half = n_times // 2
+
+brain = np.zeros((n_channels, n_times))
+for ch in range(n_channels):
+    phase = rng.uniform(0, 2 * np.pi)
+    brain[ch] = 0.6 * np.sin(2 * np.pi * 10.0 * t + phase) + 0.05 * rng.standard_normal(
+        n_times
+    )
+
+contaminated = brain.copy()
+for start in np.arange(400, n_times - 400, 600):
+    amp = 6.0 if start < half else 12.0  # statistics shift at the midpoint
+    spatial = rng.standard_normal(n_channels)
+    spatial /= np.linalg.norm(spatial)
+    contaminated[:, start : start + 200] += amp * np.outer(
+        spatial, rng.standard_normal(200)
+    )
+
+
+# %%
+# Clean with each variant
+# -----------------------
+# PSP/PSW are streamed (fit on the first third, partial_fit the rest) so their
+# adaptive update rule is exercised; MW calibrates per window inside fit.
+def stream_clean(variant):
+    est = AdaptiveASR(sfreq=sfreq, cutoff=20.0, variant=variant, verbose=False)
+    chunks = np.array_split(contaminated, 3, axis=1)
+    est.fit(chunks[0])
+    for chunk in chunks[1:]:
+        est.partial_fit(chunk)
+    return np.asarray(est.transform(contaminated))
+
+
+def scores(cleaned):
+    corr = float(np.corrcoef(cleaned.ravel(), brain.ravel())[0, 1])
+    snr_before = 10 * np.log10(np.var(brain) / np.var(contaminated - brain))
+    snr_after = 10 * np.log10(np.var(brain) / np.var(cleaned - brain))
+    return corr, float(snr_after - snr_before)
+
+
+cleaned = {"psp": stream_clean("psp"), "psw": stream_clean("psw")}
+
+mw = AdaptiveASR(
+    sfreq=sfreq, cutoff=20.0, variant="mw", mw_window_length=5.0, verbose=False
+)
+cleaned["mw"] = np.asarray(mw.fit_transform(contaminated))
+
+for variant, out in cleaned.items():
+    corr, dsnr = scores(out)
+    print(f"  {variant}:  corr-to-clean={corr:.3f}   SNR gain={dsnr:+.1f} dB")
+
+# %%
+# Variant comparison
+# ------------------
+variants = list(cleaned)
+corrs = [scores(cleaned[v])[0] for v in variants]
+dsnrs = [scores(cleaned[v])[1] for v in variants]
+
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(9, 4))
+ax1.bar(variants, corrs, color="C0")
+ax1.set_ylim(0, 1)
+ax1.set_ylabel("correlation to clean reference")
+ax1.set_title("Signal fidelity")
+ax2.bar(variants, dsnrs, color="C2")
+ax2.set_ylabel("SNR gain (dB)")
+ax2.set_title("Artifact suppression")
+fig.suptitle("Adaptive ASR variants on non-stationary data")
+fig.tight_layout()
+
+# %%
+# Moving-window adaptation trajectory
+# -----------------------------------
+# How much the threshold matrix T changes from window to window: the spike near
+# the midpoint is the MW calibration tracking the artifact-statistics shift.
+passed = [d for d in mw.mw_diagnostics_ if d["status"] == "passed"]
+t_mats = [d["T"] for d in passed]
+deltas = [
+    float(np.linalg.norm(t_mats[i] - t_mats[i - 1])) for i in range(1, len(t_mats))
+]
+centers = [
+    (passed[i]["window_start"] + passed[i]["window_stop"]) / 2 / sfreq
+    for i in range(1, len(t_mats))
+]
+
+fig2, ax = plt.subplots(figsize=(8, 4))
+ax.plot(centers, deltas, "o-", color="C3")
+ax.axvline(half / sfreq, color="0.5", ls="--", label="statistics shift")
+ax.set_xlabel("Time (s)")
+ax.set_ylabel(r"$\|T_t - T_{t-1}\|_F$")
+ax.set_title("MW-ASR adaptation trajectory")
+ax.legend()
+fig2.tight_layout()
+
+plt.show()

--- a/examples/asr/plot_09_juggler_strategies.py
+++ b/examples/asr/plot_09_juggler_strategies.py
@@ -1,0 +1,105 @@
+r"""
+Juggler ASR: DBSCAN vs GEV reference selection.
+===============================================
+
+On heavily contaminated recordings (mobile / MoBI EEG, dense brief bursts),
+ASR's window-based clean-data selector *starves* --- too few windows are clean
+enough to calibrate. Kim et al. (2025) instead select clean **samples**
+point-by-point. ``mne-denoise`` exposes two selectors via
+:class:`~mne_denoise.asr.JugglerASR`:
+
+- ``strategy="dbscan"`` -- density clustering of amplitude features (permissive);
+- ``strategy="gev"`` -- a Generalized-Extreme-Value tail fit (tighter).
+
+This example builds a densely-contaminated stream and compares how much
+calibration data each selector recovers, where the standard window selector
+struggles.
+
+References
+----------
+.. [1] Kim, S., et al. (2025). Juggler's ASR: unpacking the principles of
+   artifact subspace reconstruction for revision toward extreme MoBI.
+   Journal of Neuroscience Methods, 420, 110465.
+   doi:10.1016/j.jneumeth.2025.110465
+"""
+
+# %%
+# Densely-contaminated synthetic data
+# -----------------------------------
+# Short bursts every ~0.4 s leave only small clean gaps -- hard for a
+# window-based selector, the regime Juggler targets.
+import matplotlib.pyplot as plt
+import numpy as np
+
+from mne_denoise.asr import ASR, JugglerASR
+from mne_denoise.viz import plot_asr_calibration_fraction
+
+rng = np.random.default_rng(7)
+sfreq = 250.0
+n_channels, n_times = 12, 10000  # 40 s
+t = np.arange(n_times) / sfreq
+
+brain = np.zeros((n_channels, n_times))
+for ch in range(n_channels):
+    phase = rng.uniform(0, 2 * np.pi)
+    brain[ch] = 0.6 * np.sin(2 * np.pi * 10.0 * t + phase) + 0.05 * rng.standard_normal(
+        n_times
+    )
+
+contaminated = brain.copy()
+burst_len = int(0.1 * sfreq)
+for start in np.arange(300, n_times - burst_len, int(0.4 * sfreq)):
+    spatial = rng.standard_normal(n_channels)
+    spatial /= np.linalg.norm(spatial)
+    contaminated[:, start : start + burst_len] += 9.0 * np.outer(
+        spatial, rng.standard_normal(burst_len)
+    )
+
+# %%
+# Calibrate with the standard window selector and the two Juggler selectors
+# -------------------------------------------------------------------------
+standard = ASR(sfreq=sfreq, cutoff=20.0, picks=None, verbose=False)
+standard.fit_transform(contaminated)
+
+dbscan = JugglerASR(
+    sfreq=sfreq, cutoff=20.0, strategy="dbscan", picks=None, verbose=False
+)
+dbscan.fit_transform(contaminated)
+
+gev = JugglerASR(sfreq=sfreq, cutoff=20.0, strategy="gev", picks=None, verbose=False)
+gev.fit_transform(contaminated)
+
+print(
+    "reference fraction:  "
+    f"dbscan={dbscan.calibration_info_['reference_selected_fraction']:.2f}  "
+    f"gev={gev.calibration_info_['reference_selected_fraction']:.2f}"
+)
+
+# %%
+# Calibration fraction across selectors
+# -------------------------------------
+plot_asr_calibration_fraction(
+    [standard, dbscan, gev],
+    labels=["standard (windows)", "juggler-dbscan", "juggler-gev"],
+    title="How much calibration data each selector recovers",
+    show=False,
+)
+
+# %%
+# Reference-sample selection timeline (DBSCAN vs GEV)
+# --------------------------------------------------
+# Which individual samples each strategy trusts as clean reference, over time.
+mask_db = dbscan.get_calibration_mask()
+mask_gev = gev.get_calibration_mask()
+
+fig, ax = plt.subplots(figsize=(9, 2.6))
+ax.fill_between(t, 1.1, 1.9, where=mask_db, color="C0", step="mid", label="dbscan")
+ax.fill_between(t, 0.1, 0.9, where=mask_gev, color="C1", step="mid", label="gev")
+ax.set_yticks([0.5, 1.5])
+ax.set_yticklabels(["gev", "dbscan"])
+ax.set_xlabel("Time (s)")
+ax.set_title("Reference samples selected (shaded = kept for calibration)")
+ax.set_ylim(0, 2)
+fig.tight_layout()
+
+plt.show()

--- a/examples/asr/plot_09_juggler_strategies.py
+++ b/examples/asr/plot_09_juggler_strategies.py
@@ -17,10 +17,10 @@ struggles.
 
 References
 ----------
-.. [1] Kim, S., et al. (2025). Juggler's ASR: unpacking the principles of
-   artifact subspace reconstruction for revision toward extreme MoBI.
-   Journal of Neuroscience Methods, 420, 110465.
-   doi:10.1016/j.jneumeth.2025.110465
+* Kim, S., et al. (2025). Juggler's ASR: unpacking the principles of
+  artifact subspace reconstruction for revision toward extreme MoBI.
+  Journal of Neuroscience Methods, 420, 110465.
+  doi:10.1016/j.jneumeth.2025.110465
 """
 
 # %%
@@ -87,7 +87,7 @@ plot_asr_calibration_fraction(
 
 # %%
 # Reference-sample selection timeline (DBSCAN vs GEV)
-# --------------------------------------------------
+# ---------------------------------------------------
 # Which individual samples each strategy trusts as clean reference, over time.
 mask_db = dbscan.get_calibration_mask()
 mask_gev = gev.get_calibration_mask()

--- a/examples/asr/plot_10_choosing_a_variant.py
+++ b/examples/asr/plot_10_choosing_a_variant.py
@@ -1,0 +1,99 @@
+r"""
+Choosing an ASR variant.
+========================
+
+A runnable version of the "Choosing a variant" section of the ASR user guide.
+``mne-denoise`` ships several ASR backends; this example runs the three you will
+most often choose between on one substrate and prints a short recommendation:
+
+- ``ASR(method="standard")`` -- the right default for most EEG;
+- ``ASR(method="riemannian_windowed")`` -- Riemannian-robust calibration with a
+  working ``cutoff``;
+- ``JugglerASR(strategy="gev")`` -- sample-wise calibration that survives heavy
+  contamination where the standard window selector starves.
+
+See ``plot_06`` (cutoff), ``plot_07`` (Riemannian), ``plot_08`` (adaptive) and
+``plot_09`` (Juggler) for the per-variant deep dives.
+"""
+
+# %%
+# Synthetic substrate + helper
+# ----------------------------
+import matplotlib.pyplot as plt
+import numpy as np
+
+from mne_denoise.asr import ASR, JugglerASR, compute_asr_qa_metrics
+
+rng = np.random.default_rng(3)
+sfreq = 250.0
+n_channels, n_times = 16, 10000  # 40 s
+t = np.arange(n_times) / sfreq
+
+brain = np.zeros((n_channels, n_times))
+for ch in range(n_channels):
+    phase = rng.uniform(0, 2 * np.pi)
+    brain[ch] = 0.6 * np.sin(2 * np.pi * 10.0 * t + phase) + 0.05 * rng.standard_normal(
+        n_times
+    )
+contaminated = brain.copy()
+for start in np.linspace(600, n_times - 600, 8).astype(int):
+    spatial = rng.standard_normal(n_channels)
+    spatial /= np.linalg.norm(spatial)
+    contaminated[:, start : start + 200] += 10.0 * np.outer(
+        spatial, rng.standard_normal(200)
+    )
+
+estimators = {
+    "standard": ASR(sfreq=sfreq, cutoff=20.0, picks=None, verbose=False),
+    "riemannian_windowed": ASR(
+        sfreq=sfreq,
+        cutoff=20.0,
+        method="riemannian_windowed",
+        picks=None,
+        verbose=False,
+    ),
+    "juggler-gev": JugglerASR(
+        sfreq=sfreq, cutoff=20.0, strategy="gev", picks=None, verbose=False
+    ),
+}
+
+# %%
+# Run each variant and score it
+# -----------------------------
+rows = {}
+for name, est in estimators.items():
+    cleaned = np.asarray(est.fit_transform(contaminated))
+    metrics = compute_asr_qa_metrics(contaminated, cleaned, est)
+    corr = float(np.corrcoef(cleaned.ravel(), brain.ravel())[0, 1])
+    rows[name] = (metrics["variance_removed_pct"], corr)
+    print(
+        f"  {name:22s} variance removed={rows[name][0]:5.1f}%  corr-to-clean={corr:.3f}"
+    )
+
+# %%
+# Recommendation
+# --------------
+print("\nQuick guide:")
+print("  - most EEG ................... ASR(method='standard'), cutoff 20-30")
+print("  - robust calibration + cutoff  ASR(method='riemannian_windowed')")
+print("  - online / streaming ......... AdaptiveASR(variant='psw' or 'psp')")
+print("  - extreme MoBI / dense bursts  JugglerASR(strategy='gev' or 'dbscan')")
+
+# %%
+# Side-by-side scores
+# -------------------
+names = list(rows)
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
+ax1.bar(names, [rows[n][0] for n in names], color="C0")
+ax1.set_ylabel("% variance removed")
+ax1.set_title("Artifact suppression")
+ax1.tick_params(axis="x", labelrotation=20)
+ax2.bar(names, [rows[n][1] for n in names], color="C2")
+ax2.set_ylim(0, 1)
+ax2.set_ylabel("correlation to clean reference")
+ax2.set_title("Signal fidelity")
+ax2.tick_params(axis="x", labelrotation=20)
+fig.suptitle("Choosing an ASR variant (same data, three backends)")
+fig.tight_layout()
+
+plt.show()

--- a/examples/asr/plot_11_epochs_and_meg.py
+++ b/examples/asr/plot_11_epochs_and_meg.py
@@ -1,0 +1,105 @@
+r"""
+ASR on Epochs and on MEG.
+=========================
+
+The same :class:`~mne_denoise.asr.ASR` estimator works across MNE container
+types and channel types. This example shows two cases the other examples do not:
+
+1. **Epochs** --- calibrate on continuous ``Raw`` and clean segmented
+   ``mne.Epochs`` with the fitted model.
+2. **MEG** --- ASR is unit/scale agnostic, so ``picks="mag"`` cleans
+   magnetometers exactly as ``picks="eeg"`` cleans EEG.
+"""
+
+# %%
+# Part 1 - Epochs: fit on Raw, transform Epochs
+# ---------------------------------------------
+import matplotlib.pyplot as plt
+import mne
+import numpy as np
+
+from mne_denoise.asr import ASR
+from mne_denoise.viz import plot_signal_overlay
+
+rng = np.random.default_rng(5)
+sfreq = 250.0
+n_channels, n_times = 8, 12000  # 48 s
+t = np.arange(n_times) / sfreq
+brain = np.vstack(
+    [
+        0.6 * np.sin(2 * np.pi * 10.0 * t + rng.uniform(0, 6.28))
+        + 0.05 * rng.standard_normal(n_times)
+        for _ in range(n_channels)
+    ]
+)
+contaminated = brain.copy()
+for start in np.linspace(500, n_times - 500, 9).astype(int):
+    spatial = rng.standard_normal(n_channels)
+    spatial /= np.linalg.norm(spatial)
+    contaminated[:, start : start + 200] += 10.0 * np.outer(
+        spatial, rng.standard_normal(200)
+    )
+
+info = mne.create_info([f"EEG{i:02d}" for i in range(n_channels)], sfreq, "eeg")
+raw = mne.io.RawArray(contaminated, info, verbose="ERROR")
+events = mne.make_fixed_length_events(raw, duration=2.0)
+epochs = mne.Epochs(
+    raw, events, tmin=0.0, tmax=2.0, baseline=None, preload=True, verbose="ERROR"
+)
+
+# Calibrate on the continuous data, then clean the epochs.
+asr = ASR(cutoff=20.0, picks="eeg", verbose=False).fit(raw)
+epochs_clean = asr.transform(epochs)
+print(
+    f"Epochs in: {epochs.get_data().shape} -> cleaned: {epochs_clean.get_data().shape}"
+)
+
+before = epochs.get_data()[:, 0].ravel()
+after = epochs_clean.get_data()[:, 0].ravel()
+plot_signal_overlay(
+    before,
+    after,
+    np.arange(before.size) / sfreq,
+    scale_after=False,
+    before_label="epochs (raw)",
+    after_label="epochs (ASR)",
+    x_label="concatenated epoch time (s)",
+    y_label="Amplitude (a.u.)",
+    title="ASR on mne.Epochs (channel 0)",
+    show=False,
+)
+
+# %%
+# Part 2 - MEG: clean magnetometers
+# ---------------------------------
+# ASR is scale-agnostic, so MEG (Tesla-scale) is handled like EEG.
+sample = mne.datasets.sample.data_path()
+raw_meg = mne.io.read_raw_fif(
+    sample / "MEG" / "sample" / "sample_audvis_raw.fif", preload=True, verbose="ERROR"
+)
+raw_meg.pick("mag").crop(0, 40).resample(150, verbose="ERROR")
+raw_meg.filter(1.0, None, verbose="ERROR")
+
+asr_meg = ASR(cutoff=20.0, picks="mag", verbose=False)
+meg_clean = asr_meg.fit_transform(raw_meg.copy())
+
+var_before = float(np.var(raw_meg.get_data()))
+var_after = float(np.var(meg_clean.get_data()))
+print(f"MEG variance reduced: {100.0 * (1 - var_after / var_before):.1f}%")
+
+noisiest = int(np.argmax(np.var(raw_meg.get_data(), axis=1)))
+plot_signal_overlay(
+    raw_meg,
+    meg_clean,
+    raw_meg.times,
+    pick=raw_meg.ch_names[noisiest],
+    scale_after=False,
+    before_label="raw",
+    after_label="ASR",
+    x_label="Time (s)",
+    y_label="Amplitude (T)",
+    title=f"ASR on MEG magnetometer {raw_meg.ch_names[noisiest]}",
+    show=False,
+)
+
+plt.show()

--- a/examples/asr/plot_12_diagnostics_qc.py
+++ b/examples/asr/plot_12_diagnostics_qc.py
@@ -1,0 +1,89 @@
+r"""
+ASR diagnostics and quality control.
+====================================
+
+Every fitted ASR estimator records what it did, so you can audit the cleaning
+instead of trusting it blindly. This example tours the QC surface:
+
+- ``get_diagnostics()`` -- the per-window reconstruction record;
+- ``compute_asr_qa_metrics()`` -- scalar before/after summaries;
+- ``to_annotations(kind=...)`` -- repaired / rejected / calibration spans as
+  ``mne.Annotations`` (mark, do not delete);
+- the three ASR-specific diagnostic plots.
+"""
+
+# %%
+# Fit ASR on a synthetic Raw
+# --------------------------
+import matplotlib.pyplot as plt
+import mne
+import numpy as np
+
+from mne_denoise.asr import ASR, compute_asr_qa_metrics
+from mne_denoise.viz import (
+    plot_asr_calibration_fraction,
+    plot_asr_component_reconstruction,
+    plot_asr_repair_timeline,
+)
+
+rng = np.random.default_rng(8)
+sfreq = 250.0
+n_channels, n_times = 12, 12000
+t = np.arange(n_times) / sfreq
+brain = np.vstack(
+    [
+        0.6 * np.sin(2 * np.pi * 10.0 * t + rng.uniform(0, 6.28))
+        + 0.05 * rng.standard_normal(n_times)
+        for _ in range(n_channels)
+    ]
+)
+contaminated = brain.copy()
+for start in np.linspace(500, n_times - 500, 9).astype(int):
+    spatial = rng.standard_normal(n_channels)
+    spatial /= np.linalg.norm(spatial)
+    contaminated[:, start : start + 220] += 11.0 * np.outer(
+        spatial, rng.standard_normal(220)
+    )
+info = mne.create_info([f"EEG{i:02d}" for i in range(n_channels)], sfreq, "eeg")
+raw = mne.io.RawArray(contaminated, info, verbose="ERROR")
+
+asr = ASR(cutoff=10.0, picks="eeg", window_criterion=0.3, verbose=False)
+raw_clean = asr.fit_transform(raw)
+
+# %%
+# Diagnostics record + QA metrics
+# -------------------------------
+diag = asr.get_diagnostics()
+print("get_diagnostics() keys:", sorted(diag))
+print(
+    f"  windows={diag['n_windows']}  "
+    f"reconstructed windows={diag['fraction_reconstructed_windows']:.1%}  "
+    f"samples modified={diag['fraction_reconstructed_samples']:.1%}"
+)
+
+metrics = compute_asr_qa_metrics(raw, raw_clean, asr)
+print(
+    f"QA: variance removed={metrics['variance_removed_pct']:.1f}%  "
+    f"rms change={metrics['rms_change']:.3g}  "
+    f"median channel variance ratio={metrics['median_channel_variance_ratio']:.2f}"
+)
+
+# %%
+# Annotation export (mark, don't delete)
+# --------------------------------------
+for kind in ("repair", "rejection", "calibration"):
+    try:
+        ann = asr.to_annotations(kind=kind)
+        total = float(np.sum(ann.duration))
+        print(f"  to_annotations(kind={kind!r}): {len(ann)} spans, {total:.1f} s")
+    except (ValueError, RuntimeError) as exc:
+        print(f"  to_annotations(kind={kind!r}): not available ({exc})")
+
+# %%
+# The three ASR-specific diagnostic plots
+# ---------------------------------------
+plot_asr_repair_timeline(asr, show=False)
+plot_asr_component_reconstruction(asr, show=False)
+plot_asr_calibration_fraction(asr, show=False)
+
+plt.show()

--- a/examples/asr/plot_13_pipeline_filter_asr_ica.py
+++ b/examples/asr/plot_13_pipeline_filter_asr_ica.py
@@ -1,0 +1,89 @@
+r"""
+A realistic pipeline: filter, ASR, then ICA.
+============================================
+
+ASR sits between high-pass filtering and ICA in a standard EEG pipeline: it
+repairs high-amplitude transients *before* ICA, so the decomposition is not
+dominated by a handful of huge bursts. This capstone runs the full
+``filter -> ASR -> ICA`` workflow on real EEG (the MNE *sample* dataset) and
+shows that ICA fit on ASR-cleaned data has less extreme component activations.
+
+References
+----------
+.. [1] Mullen, T. R., et al. (2013). Real-time modeling and 3D visualization of
+   source dynamics... EMBC 2013. doi:10.1109/EMBC.2013.6609968
+.. [2] Chang, C.-Y., et al. (2020). Evaluation of Artifact Subspace
+   Reconstruction... IEEE TBME, 67(4). doi:10.1109/TBME.2019.2930186
+"""
+
+# %%
+# Load + filter real EEG
+# ----------------------
+import matplotlib.pyplot as plt
+import mne
+import numpy as np
+from scipy.stats import kurtosis
+
+from mne_denoise.asr import ASR
+from mne_denoise.viz import plot_signal_overlay
+
+sample = mne.datasets.sample.data_path()
+raw = mne.io.read_raw_fif(
+    sample / "MEG" / "sample" / "sample_audvis_raw.fif", preload=True, verbose="ERROR"
+)
+raw.pick("eeg").crop(0, 60).resample(150, verbose="ERROR")
+raw.set_eeg_reference("average", verbose="ERROR")
+raw.filter(1.0, None, verbose="ERROR")  # 1) high-pass
+
+# %%
+# Apply ASR
+# ---------
+asr = ASR(cutoff=20.0, picks="eeg", verbose=False)
+raw_asr = asr.fit_transform(raw.copy())  # 2) ASR burst repair
+
+noisiest = int(np.argmax(np.var(raw.get_data(), axis=1)))
+plot_signal_overlay(
+    raw,
+    raw_asr,
+    raw.times,
+    pick=raw.ch_names[noisiest],
+    scale_after=False,
+    before_label="filtered",
+    after_label="filtered + ASR",
+    x_label="Time (s)",
+    y_label="Amplitude (V)",
+    title=f"ASR burst repair on {raw.ch_names[noisiest]}",
+    show=False,
+)
+
+# %%
+# Fit ICA on raw vs ASR-cleaned
+# -----------------------------
+# Same settings on both; compare how extreme the recovered sources are.
+ica_kw = {"n_components": 15, "max_iter": 300, "random_state": 97}
+ica_raw = mne.preprocessing.ICA(**ica_kw).fit(raw, verbose="ERROR")  # 3) ICA
+ica_asr = mne.preprocessing.ICA(**ica_kw).fit(raw_asr, verbose="ERROR")
+
+src_raw = ica_raw.get_sources(raw).get_data()
+src_asr = ica_asr.get_sources(raw_asr).get_data()
+max_raw = float(np.max(np.abs(src_raw)))
+max_asr = float(np.max(np.abs(src_asr)))
+kurt_raw = float(np.mean(kurtosis(src_raw, axis=1)))
+kurt_asr = float(np.mean(kurtosis(src_asr, axis=1)))
+print(f"max |IC activation|:  raw={max_raw:.1f}  ASR={max_asr:.1f}")
+print(f"mean IC excess kurtosis:  raw={kurt_raw:.1f}  ASR={kurt_asr:.1f}")
+
+# %%
+# ICA component "peakiness" before vs after ASR
+# ---------------------------------------------
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(9, 4))
+ax1.bar(["raw", "ASR-cleaned"], [max_raw, max_asr], color=["0.6", "C0"])
+ax1.set_ylabel("max |IC activation|")
+ax1.set_title("Largest transient captured by ICA")
+ax2.bar(["raw", "ASR-cleaned"], [kurt_raw, kurt_asr], color=["0.6", "C2"])
+ax2.set_ylabel("mean IC excess kurtosis")
+ax2.set_title("How burst-dominated the ICs are")
+fig.suptitle("ICA after ASR is less dominated by transients")
+fig.tight_layout()
+
+plt.show()

--- a/examples/asr/plot_13_pipeline_filter_asr_ica.py
+++ b/examples/asr/plot_13_pipeline_filter_asr_ica.py
@@ -10,10 +10,10 @@ shows that ICA fit on ASR-cleaned data has less extreme component activations.
 
 References
 ----------
-.. [1] Mullen, T. R., et al. (2013). Real-time modeling and 3D visualization of
-   source dynamics... EMBC 2013. doi:10.1109/EMBC.2013.6609968
-.. [2] Chang, C.-Y., et al. (2020). Evaluation of Artifact Subspace
-   Reconstruction... IEEE TBME, 67(4). doi:10.1109/TBME.2019.2930186
+* Mullen, T. R., et al. (2013). Real-time modeling and 3D visualization of
+  source dynamics... EMBC 2013. doi:10.1109/EMBC.2013.6609968
+* Chang, C.-Y., et al. (2020). Evaluation of Artifact Subspace
+  Reconstruction... IEEE TBME, 67(4). doi:10.1109/TBME.2019.2930186
 """
 
 # %%


### PR DESCRIPTION
## Summary

Extends the ASR example gallery from **5 to 13** so every variant and common
use-case is shown, with each method example **grounded in (and citing) its
source paper**. Stacked on #40 (the `core.py` refactor) so the diff here is
examples-only; it retargets to `feature/ASR` when #40 merges. **For review --
not for immediate merge.**

## New examples (`plot_06`..`plot_13`)

| Example | Shows | Paper | Data |
|---|---|---|---|
| `plot_06_cutoff_tuning` | % data modified & variance removed vs cutoff | Chang 2020 | synthetic |
| `plot_07_riemannian_asr` | rASR vs standard, frontal blink removal | Blum 2019 | mne.sample |
| `plot_08_adaptive_variants` | psp/psw/mw + moving-window trajectory | Tsai | synthetic |
| `plot_09_juggler_strategies` | dbscan vs gev reference selection | Kim 2025 | synthetic |
| `plot_10_choosing_a_variant` | standard vs rASR vs Juggler + guidance | -- | synthetic |
| `plot_11_epochs_and_meg` | ASR on Epochs and on MEG magnetometers | -- | synthetic + mne.sample |
| `plot_12_diagnostics_qc` | get_diagnostics / QA / to_annotations + 3 ASR plots | -- | synthetic |
| `plot_13_pipeline_filter_asr_ica` | filter -> ASR -> ICA (capstone) | Mullen/Chang | mne.sample |

## Notes
- Reuses existing viz + QA helpers; **no new API**.
- Real-data examples (07, 13, MEG part of 11) use `mne.datasets.sample`
  (same precedent as the DSS gallery).
- Each example runs headless (exit 0); `ruff check` + `ruff format` clean;
  `README.rst` regrouped to list all 13.
- Findings are reported honestly (e.g. on clean `sample` data, standard and
  Riemannian ASR are comparable -- rASR's edge is robustness to contaminated
  calibration, by design).
