### PR TITLE
ENH: clarify DSS temporal bias and cycle timing contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - **Linear DSS**: Extract components based on reproducibility across trials or characteristic frequencies
 - **Iterative DSS**: Powerful nonlinear separation for complex non-Gaussian sources
 - **20+ Pluggable Denoisers**: Spectral, temporal, periodic, and ICA-style bias functions
-- **Specialized Variants**: TSR, SSVEP enhancement, narrowband oscillation extraction
+- **Specialized Variants**: lag averaging, SSVEP enhancement, narrowband extraction
 
 ### ZapLine Module
 
@@ -131,11 +131,11 @@ mne_denoise/
 │   ├── nonlinear.py        # Iterative DSS, IterativeDSS estimator
 │   ├── denoisers/          # 20+ pluggable bias functions
 │   │   ├── spectral.py     # BandpassBias, LineNoiseBias
-│   │   ├── temporal.py     # TimeShiftBias, SmoothingBias
+│   │   ├── temporal.py     # LagAveragingBias, SmoothingBias
 │   │   ├── periodic.py     # CombFilterBias, PeakFilterBias
 │   │   └── ...
 │   └── variants/           # Pre-built applications
-│       ├── tsr.py          # Time-Shift Repeatability
+│       ├── tsr.py          # Lag averaging and temporal smoothing
 │       ├── ssvep.py        # SSVEP enhancement
 │       └── narrowband.py   # Oscillation extraction
 ├── zapline/                # Line noise removal

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -76,6 +76,7 @@ Denoisers
    mne_denoise.dss.denoisers.LineNoiseBias
    mne_denoise.dss.denoisers.PeakFilterBias
    mne_denoise.dss.denoisers.CombFilterBias
+   mne_denoise.dss.denoisers.LagAveragingBias
    mne_denoise.dss.denoisers.TimeShiftBias
    mne_denoise.dss.denoisers.SmoothingBias
    mne_denoise.dss.denoisers.SpectrogramBias
@@ -96,6 +97,7 @@ Variants
    :toctree: generated/
    :nosignatures:
 
+   mne_denoise.dss.variants.lag_averaging_dss
    mne_denoise.dss.variants.time_shift_dss
    mne_denoise.dss.variants.smooth_dss
    mne_denoise.dss.variants.narrowband_dss

--- a/docs/changes/devel/57.feature.rst
+++ b/docs/changes/devel/57.feature.rst
@@ -1,0 +1,5 @@
+**DSS**:
+- Added the canonical ``LagAveragingBias`` and ``lag_averaging_dss`` names for
+  the existing bias-side lag average. ``CycleAverageBias`` now has explicit
+  sample/second window units and data-relative/MNE Raw event origins, including
+  a single documented ``first_samp`` conversion.

--- a/docs/changes/devel/57.removal.rst
+++ b/docs/changes/devel/57.removal.rst
@@ -1,0 +1,6 @@
+**DSS**:
+- Deprecated ``TimeShiftBias`` and ``time_shift_dss`` in favor of
+  ``LagAveragingBias`` and ``lag_averaging_dss``. Deprecated implicit
+  ``CycleAverageBias`` window units and event origins. These 0.x compatibility
+  paths emit ``FutureWarning`` and are scheduled for removal in 1.0;
+  ``TimeShiftDSS`` remains reserved for a future true lag-augmented estimator.

--- a/docs/dss.md
+++ b/docs/dss.md
@@ -104,24 +104,50 @@ print(f"Power reduction: {est.n_removed_} components")
 
 | Class              | Use Case             | Description                              |
 | ------------------ | -------------------- | ---------------------------------------- |
-| `TrialAverageBias` | Evoked responses     | Epoch averaging for phase-locked signals |
+| `AverageBias`      | Evoked responses     | Epoch averaging for phase-locked signals |
 | `BandpassBias`     | Rhythm extraction    | Narrow-band filter for oscillations      |
 | `NotchBias`        | Line noise isolation | Isolate specific frequency               |
 | `CycleAverageBias` | Artifact removal     | Cycle-locked averaging for ECG/blinks    |
+| `LagAveragingBias` | Predictable signals  | Average explicitly selected sample lags  |
 
 Example usage:
 
 ```python
-from mne_denoise.dss import TrialAverageBias, CycleAverageBias
+import mne
+
+from mne_denoise.dss import (
+    AverageBias,
+    CycleAverageBias,
+    DSS,
+    LagAveragingBias,
+)
 
 # Evoked response enhancement
 epochs_data = np.random.randn(64, 200, 100)  # channels x times x epochs
-bias = TrialAverageBias()
+bias = AverageBias()
 
-# ECG artifact removal
-r_peaks = find_r_peaks(ecg_signal)
-bias = CycleAverageBias(event_samples=r_peaks, window=(-0.1, 0.3), sfreq=500)
+# ECG artifact removal from MNE Raw events. MNE event positions use the
+# acquisition coordinate system, so declare the origin and offset explicitly.
+events, _, _ = mne.preprocessing.find_ecg_events(raw)
+bias = CycleAverageBias(
+    event_samples=events[:, 0],
+    window=(-0.1, 0.3),
+    window_unit="seconds",
+    sfreq=raw.info["sfreq"],
+    event_origin="raw",
+    first_samp=raw.first_samp,
+)
+
+# Extract components emphasized by a bias-side average of selected lags.
+lag_bias = LagAveragingBias(shifts=[1, 2, 5, 10])
+lag_dss = DSS(bias=lag_bias, n_components=5, component_action="extract")
 ```
+
+`LagAveragingBias` and `lag_averaging_dss` are the canonical names for the
+released bias-side operation. `TimeShiftBias` and `time_shift_dss` remain as
+0.x compatibility names and emit `FutureWarning`. They are not true
+time-shift DSS: the `TimeShiftDSS` name is reserved for a future estimator that
+augments the data with lagged copies and learns spatiotemporal filters.
 
 ### Nonlinear Biases
 

--- a/examples/dss/plot_02_artifact_correction.py
+++ b/examples/dss/plot_02_artifact_correction.py
@@ -206,7 +206,13 @@ print(f"Found {len(blink_samples)} blink events")
 # Create CycleAverageBias
 # Window: 100ms before to 100ms after each blink (in samples)
 window_samples = (-int(0.1 * raw.info["sfreq"]), int(0.1 * raw.info["sfreq"]))
-bias_cycle = CycleAverageBias(event_samples=blink_samples, window=window_samples)
+bias_cycle = CycleAverageBias(
+    event_samples=blink_samples,
+    window=window_samples,
+    window_unit="samples",
+    event_origin="raw",
+    first_samp=raw_meg.first_samp,
+)
 
 # Fit DSS on continuous MEG data
 dss_cycle = DSS(n_components=10, bias=bias_cycle, return_type="sources")

--- a/examples/dss/plot_06_temporal_dss.py
+++ b/examples/dss/plot_06_temporal_dss.py
@@ -1,15 +1,15 @@
 """
-=================================================
-Temporal DSS: Time-Shift Regression & Smoothness.
-=================================================
+=========================================
+Temporal DSS: Lag Averaging & Smoothness.
+=========================================
 
 This example demonstrates DSS for extracting **temporally structured** signals:
 autocorrelated components, slow drifts, and smooth waveforms.
 
-We cover both **linear biases** (TimeShiftBias, SmoothingBias) and
+We cover both **linear biases** (LagAveragingBias, SmoothingBias) and
 **nonlinear denoisers** (DCTDenoiser, TemporalSmoothnessDenoiser).
 
-The examples move from synthetic slow drifts to time-shift and smoothing
+The examples move from synthetic slow drifts to lag-averaging and smoothing
 biases, then to DCT-based iterative denoising and a real EEG slow-potential
 example.
 
@@ -29,10 +29,10 @@ from scipy import signal
 from mne_denoise.dss import DSS, IterativeDSS
 from mne_denoise.dss.denoisers import (
     DCTDenoiser,
+    LagAveragingBias,
     SmoothingBias,
-    TimeShiftBias,
 )
-from mne_denoise.dss.variants import smooth_dss, time_shift_dss
+from mne_denoise.dss.variants import lag_averaging_dss, smooth_dss
 from mne_denoise.viz import (
     plot_channel_time_course_comparison,
     plot_component_summary,
@@ -116,21 +116,21 @@ plt.show()
 
 
 # %%
-# Part 1: Time-Shift Regression (TimeShiftBias)
-# ==============================================
-# TSR finds components that are autocorrelated across time lags
+# Part 1: Bias-side lag averaging (LagAveragingBias)
+# ==================================================
+# Lag averaging finds components that are autocorrelated across time lags.
 
-print("\n--- Part 1: Time-Shift Regression ---")
+print("\n--- Part 1: Bias-side lag averaging ---")
 
-# Manual TimeShiftBias
-bias_tsr = TimeShiftBias(shifts=10, method="autocorrelation")
+# Manual LagAveragingBias
+bias_tsr = LagAveragingBias(shifts=10, method="autocorrelation")
 dss_tsr_manual = DSS(n_components=5, bias=bias_tsr)
 dss_tsr_manual.fit(raw_sim)
 
 print(f"Manual DSS Eigenvalues: {dss_tsr_manual.eigenvalues_[:5]}")
 
 # Wrapper for comparison
-dss_tsr_wrapper = time_shift_dss(shifts=10, n_components=5)
+dss_tsr_wrapper = lag_averaging_dss(shifts=10, n_components=5)
 dss_tsr_wrapper.fit(raw_sim)
 
 print(f"Wrapper Eigenvalues: {dss_tsr_wrapper.eigenvalues_[:5]}")
@@ -145,7 +145,7 @@ plot_component_summary(
     n_components=3,
     show=False,
 )
-plt.gcf().suptitle("TimeShiftBias (TSR): Autocorrelated Components")
+plt.gcf().suptitle("LagAveragingBias: Autocorrelated Components")
 plt.show()
 
 # %%
@@ -169,12 +169,12 @@ plt.plot(
     comp0_tsr[:2000] * (np.std(drift) / np.std(comp0_tsr)),
     "r",
     linewidth=1.5,
-    label=f"TSR Component 0 (r={corr_tsr:.3f})",
+    label=f"Lag-average component 0 (r={corr_tsr:.3f})",
     alpha=0.8,
 )
 plt.xlabel("Time (s)")
 plt.ylabel("Amplitude (scaled)")
-plt.title("Time-Shift Regression: Extracted Slow Drift")
+plt.title("Lag averaging: Extracted slow drift")
 plt.legend()
 plt.grid(True, alpha=0.3)
 plt.tight_layout()
@@ -279,8 +279,13 @@ axes[0].set_ylabel("Amplitude")
 axes[0].legend()
 axes[0].grid(True, alpha=0.3)
 
-axes[1].plot(t_compare, comp0_tsr[:2000] * scale, "r", label=f"TSR (r={corr_tsr:.3f})")
-axes[1].set_title("TimeShiftBias (Time-Shift Regression)")
+axes[1].plot(
+    t_compare,
+    comp0_tsr[:2000] * scale,
+    "r",
+    label=f"Lag averaging (r={corr_tsr:.3f})",
+)
+axes[1].set_title("LagAveragingBias (bias-side lag averaging)")
 axes[1].set_ylabel("Amplitude")
 axes[1].legend()
 axes[1].grid(True, alpha=0.3)
@@ -311,7 +316,7 @@ print("\n--- All methods successfully extract the slow drift ---")
 # %%
 # Part 4: Real EEG Data (Slow Cortical Potentials)
 # =================================================
-# Apply TSR to real EEG for slow drift extraction
+# Apply lag-averaging DSS to real EEG for slow-drift extraction.
 
 print("\n--- Part 4: Real EEG Data ---")
 
@@ -342,11 +347,11 @@ raw_eeg.crop(0, 30)  # 30 seconds
 
 print(f"EEG Data: {len(raw_eeg.ch_names)} channels, {raw_eeg.times[-1]:.1f}s")
 
-# Apply TSR
-dss_eeg_tsr = time_shift_dss(shifts=10, n_components=5)
+# Apply lag-averaging DSS.
+dss_eeg_tsr = lag_averaging_dss(shifts=10, n_components=5)
 dss_eeg_tsr.fit(raw_eeg)
 
-print(f"\nTSR Eigenvalues: {dss_eeg_tsr.eigenvalues_[:5]}")
+print(f"\nLag-averaging eigenvalues: {dss_eeg_tsr.eigenvalues_[:5]}")
 
 # Get sources for visualization
 sources_eeg = dss_eeg_tsr.transform(raw_eeg)
@@ -366,7 +371,7 @@ plot_channel_time_course_comparison(
     stop=int(10 * raw_single.info["sfreq"]),
     show=False,
 )
-plt.gcf().suptitle("Real EEG: Original vs TSR Component 0")
+plt.gcf().suptitle("Real EEG: Original vs lag-average component 0")
 plt.show()
 
 # %%
@@ -374,4 +379,4 @@ plot_psd_comparison(raw_single, comp_raw, fmin=0.1, fmax=10, show=False)
 plt.gcf().axes[0].set_title("Real EEG: PSD Comparison (Slow Oscillations)")
 plt.show()
 
-print("\nTSR successfully extracted slow cortical potentials from real EEG!")
+print("\nLag averaging extracted slow cortical potentials from real EEG!")

--- a/mne_denoise/dss/__init__.py
+++ b/mne_denoise/dss/__init__.py
@@ -17,6 +17,7 @@ from .denoisers import (
     DCTDenoiser,
     GaussDenoiser,
     KurtosisDenoiser,
+    LagAveragingBias,
     LinearDenoiser,
     LineNoiseBias,
     NonlinearDenoiser,
@@ -54,7 +55,7 @@ from .variants.narrowband import narrowband_dss, narrowband_scan
 from .variants.ssvep import ssvep_dss
 
 # Variants (Direct Access)
-from .variants.tsr import smooth_dss, time_shift_dss
+from .variants.tsr import lag_averaging_dss, smooth_dss, time_shift_dss
 
 __all__ = [
     # Core
@@ -68,6 +69,7 @@ __all__ = [
     "ssvep",
     "narrowband",
     # Variants functions
+    "lag_averaging_dss",
     "time_shift_dss",
     "smooth_dss",
     "ssvep_dss",
@@ -85,6 +87,7 @@ __all__ = [
     "PeakFilterBias",
     "CombFilterBias",
     "CycleAverageBias",
+    "LagAveragingBias",
     "WienerMaskDenoiser",
     "TanhMaskDenoiser",
     "RobustTanhDenoiser",

--- a/mne_denoise/dss/denoisers/__init__.py
+++ b/mne_denoise/dss/denoisers/__init__.py
@@ -28,6 +28,7 @@ from .spectral import (
 from .spectrogram import SpectrogramBias, SpectrogramDenoiser
 from .temporal import (
     DCTDenoiser,
+    LagAveragingBias,
     SmoothingBias,
     TimeShiftBias,
 )
@@ -39,11 +40,12 @@ __all__ = [
     # Linear biases
     "AverageBias",
     "BandpassBias",
-    "BandpassBias",
     "LineNoiseBias",
     "PeakFilterBias",
     "CombFilterBias",
     "CycleAverageBias",
+    "LagAveragingBias",
+    "SmoothingBias",
     # Nonlinear denoisers (paper-faithful)
     "VarianceMaskDenoiser",
     "WienerMaskDenoiser",
@@ -63,5 +65,4 @@ __all__ = [
     "beta_gauss",
     # Deprecated
     "TimeShiftBias",
-    "SmoothingBias",
 ]

--- a/mne_denoise/dss/denoisers/artifact.py
+++ b/mne_denoise/dss/denoisers/artifact.py
@@ -13,7 +13,9 @@ References
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Sequence
+from typing import Literal
 
 import numpy as np
 
@@ -29,31 +31,60 @@ class CycleAverageBias(LinearDenoiser):
 
     Parameters
     ----------
-    event_samples : array-like
-        Sample indices of artifact events (e.g., R-peak locations).
-    window : tuple of int
-        (pre, post) samples around each event to include.
-        Default (-100, 200) for ~300ms window at 1kHz.
+    event_samples : array-like of int
+        Sample indices of artifact events (e.g., R-peak locations). Their
+        coordinate system is declared by ``event_origin``.
+    window : tuple of int or float
+        Half-open interval ``(start, stop)`` around each event. Its unit is
+        declared by ``window_unit``. The default is ``(-100, 200)``.
+    window_unit : {"samples", "seconds"} | None
+        Unit of ``window``. Canonical calls must specify this explicitly. If
+        ``None``, the 0.x compatibility behavior infers seconds when ``sfreq``
+        is provided and samples otherwise, and emits ``FutureWarning``.
     sfreq : float, optional
-        Sampling frequency for window specification in seconds.
-        If provided, window can be in seconds instead of samples.
+        Sampling frequency in Hz. Required when ``window_unit="seconds"``.
+        Second-valued boundaries are converted exactly once at construction by
+        rounding to the nearest sample with :func:`numpy.rint`.
+    event_origin : {"data", "raw"} | None
+        ``"data"`` means event zero is the first sample of the array passed to
+        :meth:`apply`. ``"raw"`` means MNE acquisition sample numbering (for
+        example, column zero from an MNE events array); ``first_samp`` is then
+        subtracted exactly once at construction. Canonical calls must specify
+        this explicitly. ``None`` retains the 0.x data-relative behavior and
+        emits ``FutureWarning``.
+    first_samp : int, optional
+        First acquisition sample of the corresponding MNE Raw object. Required
+        for ``event_origin="raw"`` and forbidden for ``event_origin="data"``.
 
     Examples
     --------
     >>> # ECG artifact removal
     >>> from mne.preprocessing import find_ecg_events
     >>> from mne_denoise.dss.denoisers import CycleAverageBias
-    >>> r_peaks, _ = find_ecg_events(raw)  # MNE returns events array
+    >>> r_peaks, _, _ = find_ecg_events(raw)  # MNE returns events array
     >>> # Extract sample indices (column 0)
     >>> r_peak_samples = r_peaks[:, 0]
-    >>> bias = CycleAverageBias(event_samples=r_peak_samples, window=(-100, 200))
+    >>> bias = CycleAverageBias(
+    ...     event_samples=r_peak_samples,
+    ...     window=(-0.1, 0.2),
+    ...     window_unit="seconds",
+    ...     sfreq=raw.info["sfreq"],
+    ...     event_origin="raw",
+    ...     first_samp=raw.first_samp,
+    ... )
     >>> biased_data = bias.apply(raw.get_data())
 
     >>> # EOG (blink) artifact removal
     >>> from mne.preprocessing import find_eog_events
     >>> blinks = find_eog_events(raw)
     >>> blink_samples = blinks[:, 0]
-    >>> bias_eog = CycleAverageBias(event_samples=blink_samples, window=(-200, 200))
+    >>> bias_eog = CycleAverageBias(
+    ...     event_samples=blink_samples,
+    ...     window=(-200, 200),
+    ...     window_unit="samples",
+    ...     event_origin="raw",
+    ...     first_samp=raw.first_samp,
+    ... )
     >>> biased_eog = bias_eog.apply(raw.get_data())
 
     References
@@ -64,20 +95,158 @@ class CycleAverageBias(LinearDenoiser):
     def __init__(
         self,
         event_samples: Sequence[int],
-        window: tuple[int, int] = (-100, 200),
+        window: tuple[int | float, int | float] = (-100, 200),
         *,
+        window_unit: Literal["samples", "seconds"] | None = None,
         sfreq: float | None = None,
+        event_origin: Literal["data", "raw"] | None = None,
+        first_samp: int | None = None,
     ) -> None:
-        self.event_samples = np.asarray(event_samples, dtype=int)
-
-        # Convert window to samples if sfreq provided
-        if sfreq is not None:
-            self.window = (int(window[0] * sfreq), int(window[1] * sfreq))
-        else:
-            self.window = (int(window[0]), int(window[1]))
-
-        self.sfreq = sfreq
+        self.event_samples = self._validate_event_samples(event_samples)
+        self.window_input = self._validate_window(window)
+        self.window_unit = self._resolve_window_unit(window_unit, sfreq)
+        self.sfreq = self._validate_sfreq(sfreq, self.window_unit)
+        self.window = self._window_to_samples(
+            self.window_input,
+            window_unit=self.window_unit,
+            sfreq=self.sfreq,
+        )
+        self.event_origin = self._resolve_event_origin(event_origin)
+        self.first_samp = self._validate_first_samp(first_samp, self.event_origin)
+        event_offset = 0 if self.first_samp is None else self.first_samp
+        self.event_offset_samples_ = int(event_offset)
+        self.event_samples_data_ = self.event_samples - self.event_offset_samples_
         self._window_length = self.window[1] - self.window[0]
+
+    @staticmethod
+    def _validate_event_samples(event_samples: Sequence[int]) -> np.ndarray:
+        """Return event positions without silently truncating values."""
+        events = np.asarray(event_samples)
+        if events.ndim != 1:
+            raise ValueError("event_samples must be a one-dimensional sequence.")
+        if not np.issubdtype(events.dtype, np.number) or not np.all(
+            np.isfinite(events)
+        ):
+            raise ValueError("event_samples must contain only finite integers.")
+        if not np.all(events == np.rint(events)):
+            raise ValueError("event_samples must contain integer sample indices.")
+        return events.astype(np.int64, copy=True)
+
+    @staticmethod
+    def _validate_window(
+        window: tuple[int | float, int | float],
+    ) -> tuple[float, float]:
+        """Validate a two-boundary finite window."""
+        values = np.asarray(window)
+        if values.shape != (2,) or not np.issubdtype(values.dtype, np.number):
+            raise ValueError("window must contain exactly two numeric boundaries.")
+        if not np.all(np.isfinite(values)):
+            raise ValueError("window boundaries must be finite.")
+        start, stop = (float(values[0]), float(values[1]))
+        if start >= stop:
+            raise ValueError("window start must be strictly less than window stop.")
+        return start, stop
+
+    @staticmethod
+    def _resolve_window_unit(
+        window_unit: Literal["samples", "seconds"] | None,
+        sfreq: float | None,
+    ) -> Literal["samples", "seconds"]:
+        """Resolve the deprecated unit inference used by released 0.x code."""
+        if window_unit is None:
+            inferred = "seconds" if sfreq is not None else "samples"
+            warnings.warn(
+                "Implicit CycleAverageBias window units are deprecated and will "
+                "be removed in mne-denoise 1.0; pass window_unit='samples' or "
+                "window_unit='seconds' explicitly.",
+                FutureWarning,
+                stacklevel=3,
+            )
+            return inferred
+        if window_unit not in {"samples", "seconds"}:
+            raise ValueError(
+                f"window_unit must be 'samples' or 'seconds', got {window_unit!r}."
+            )
+        return window_unit
+
+    @staticmethod
+    def _validate_sfreq(
+        sfreq: float | None,
+        window_unit: Literal["samples", "seconds"],
+    ) -> float | None:
+        """Validate sampling frequency only when supplied or required."""
+        if sfreq is None:
+            if window_unit == "seconds":
+                raise ValueError("sfreq is required when window_unit='seconds'.")
+            return None
+        if isinstance(sfreq, bool) or not np.isfinite(sfreq) or float(sfreq) <= 0:
+            raise ValueError("sfreq must be a finite positive number.")
+        return float(sfreq)
+
+    @staticmethod
+    def _window_to_samples(
+        window: tuple[float, float],
+        *,
+        window_unit: Literal["samples", "seconds"],
+        sfreq: float | None,
+    ) -> tuple[int, int]:
+        """Convert a validated interval to integer sample boundaries once."""
+        values = np.asarray(window)
+        if window_unit == "samples":
+            if not np.all(values == np.rint(values)):
+                raise ValueError(
+                    "window boundaries must be integers when window_unit='samples'."
+                )
+            samples = np.rint(values).astype(int)
+        else:
+            # _validate_sfreq guarantees this for the seconds pathway.
+            assert sfreq is not None
+            samples = np.rint(values * sfreq).astype(int)
+        if samples[0] >= samples[1]:
+            raise ValueError(
+                "window resolves to an empty or reversed sample interval; "
+                "increase its duration or sfreq."
+            )
+        return int(samples[0]), int(samples[1])
+
+    @staticmethod
+    def _resolve_event_origin(
+        event_origin: Literal["data", "raw"] | None,
+    ) -> Literal["data", "raw"]:
+        """Resolve the deprecated data-relative origin used by 0.x code."""
+        if event_origin is None:
+            warnings.warn(
+                "Implicit CycleAverageBias event origin is deprecated and will "
+                "be removed in mne-denoise 1.0; pass event_origin='data' or "
+                "event_origin='raw' explicitly.",
+                FutureWarning,
+                stacklevel=3,
+            )
+            return "data"
+        if event_origin not in {"data", "raw"}:
+            raise ValueError(
+                f"event_origin must be 'data' or 'raw', got {event_origin!r}."
+            )
+        return event_origin
+
+    @staticmethod
+    def _validate_first_samp(
+        first_samp: int | None,
+        event_origin: Literal["data", "raw"],
+    ) -> int | None:
+        """Validate the sole offset used to map events into data coordinates."""
+        if event_origin == "raw" and first_samp is None:
+            raise ValueError("first_samp is required when event_origin='raw'.")
+        if event_origin == "data" and first_samp is not None:
+            raise ValueError(
+                "first_samp must be omitted when event_origin='data'; the event "
+                "samples are already relative to the supplied data."
+            )
+        if first_samp is None:
+            return None
+        if not isinstance(first_samp, int | np.integer) or isinstance(first_samp, bool):
+            raise TypeError("first_samp must be an integer.")
+        return int(first_samp)
 
     def apply(self, data: np.ndarray) -> np.ndarray:
         """Apply cycle averaging bias.
@@ -92,13 +261,14 @@ class CycleAverageBias(LinearDenoiser):
         biased : ndarray, same shape as input
             Data where artifact-locked segments are replaced by cycle average.
         """
+        data = np.asarray(data)
         original_shape = data.shape
 
         # Handle 3D epoched data by concatenating
         if data.ndim == 3:
             n_channels, n_times, n_epochs = data.shape
             # Adjust events for concatenated epochs
-            data_2d = data.reshape(n_channels, -1)
+            data_2d = data.transpose(0, 2, 1).reshape(n_channels, -1)
             total_samples = n_times * n_epochs
         elif data.ndim == 2:
             data_2d = data
@@ -108,10 +278,10 @@ class CycleAverageBias(LinearDenoiser):
 
         # Filter valid events (within data bounds)
         pre, post = self.window
-        valid_mask = (self.event_samples + pre >= 0) & (
-            self.event_samples + post <= total_samples
+        valid_mask = (self.event_samples_data_ + pre >= 0) & (
+            self.event_samples_data_ + post <= total_samples
         )
-        valid_events = self.event_samples[valid_mask]
+        valid_events = self.event_samples_data_[valid_mask]
 
         if len(valid_events) == 0:
             # No valid events, return zeros (no artifact signal)
@@ -139,7 +309,9 @@ class CycleAverageBias(LinearDenoiser):
 
         # Reshape back if needed
         if len(original_shape) == 3:
-            biased = biased_2d.reshape(original_shape)
+            biased = biased_2d.reshape(
+                original_shape[0], original_shape[2], original_shape[1]
+            ).transpose(0, 2, 1)
         else:
             biased = biased_2d
 

--- a/mne_denoise/dss/denoisers/artifact.py
+++ b/mne_denoise/dss/denoisers/artifact.py
@@ -33,10 +33,13 @@ class CycleAverageBias(LinearDenoiser):
     ----------
     event_samples : array-like of int
         Sample indices of artifact events (e.g., R-peak locations). Their
-        coordinate system is declared by ``event_origin``.
+        coordinate system is declared by ``event_origin``. Values must fit in
+        the signed 64-bit sample range; out-of-range coordinates are rejected
+        instead of wrapped.
     window : tuple of int or float
         Half-open interval ``(start, stop)`` around each event. Its unit is
-        declared by ``window_unit``. The default is ``(-100, 200)``.
+        declared by ``window_unit``. Resolved sample boundaries must fit in the
+        signed 64-bit sample range. The default is ``(-100, 200)``.
     window_unit : {"samples", "seconds"} | None
         Unit of ``window``. Canonical calls must specify this explicitly. If
         ``None``, the 0.x compatibility behavior infers seconds when ``sfreq``
@@ -44,7 +47,7 @@ class CycleAverageBias(LinearDenoiser):
     sfreq : float, optional
         Sampling frequency in Hz. Required when ``window_unit="seconds"``.
         Second-valued boundaries are converted exactly once at construction by
-        rounding to the nearest sample with :func:`numpy.rint`.
+        rounding to the nearest sample (ties to even).
     event_origin : {"data", "raw"} | None
         ``"data"`` means event zero is the first sample of the array passed to
         :meth:`apply`. ``"raw"`` means MNE acquisition sample numbering (for
@@ -115,34 +118,77 @@ class CycleAverageBias(LinearDenoiser):
         self.first_samp = self._validate_first_samp(first_samp, self.event_origin)
         event_offset = 0 if self.first_samp is None else self.first_samp
         self.event_offset_samples_ = int(event_offset)
-        self.event_samples_data_ = self.event_samples - self.event_offset_samples_
+        data_events = [
+            int(event) - self.event_offset_samples_ for event in self.event_samples
+        ]
+        self.event_samples_data_ = self._as_int64(
+            data_events,
+            "event_samples after applying first_samp",
+        )
         self._window_length = self.window[1] - self.window[0]
 
     @staticmethod
-    def _validate_event_samples(event_samples: Sequence[int]) -> np.ndarray:
-        """Return event positions without silently truncating values."""
+    def _as_int64(values: Sequence[int | float], name: str) -> np.ndarray:
+        """Return exact integral values represented safely as signed int64."""
+        array = np.asarray(values)
+        if array.ndim != 1:
+            raise ValueError(f"{name} must be a one-dimensional sequence.")
+
+        minimum = int(np.iinfo(np.int64).min)
+        maximum = int(np.iinfo(np.int64).max)
+        converted: list[int] = []
+        for value in array.tolist():
+            if isinstance(value, (bool, np.bool_)):
+                raise ValueError(f"{name} must contain only finite integers.")
+            if isinstance(value, (int, np.integer)):
+                integer = int(value)
+            elif isinstance(value, (float, np.floating)):
+                scalar = float(value)
+                if not np.isfinite(scalar) or not scalar.is_integer():
+                    raise ValueError(f"{name} must contain only finite integers.")
+                integer = int(scalar)
+            else:
+                raise ValueError(f"{name} must contain only finite integers.")
+            if integer < minimum or integer > maximum:
+                raise ValueError(f"{name} values must fit in signed 64-bit samples.")
+            converted.append(integer)
+        return np.asarray(converted, dtype=np.int64)
+
+    @classmethod
+    def _validate_event_samples(cls, event_samples: Sequence[int]) -> np.ndarray:
+        """Return event positions without truncation or integer wraparound."""
         events = np.asarray(event_samples)
         if events.ndim != 1:
             raise ValueError("event_samples must be a one-dimensional sequence.")
-        if not np.issubdtype(events.dtype, np.number) or not np.all(
-            np.isfinite(events)
-        ):
-            raise ValueError("event_samples must contain only finite integers.")
-        if not np.all(events == np.rint(events)):
-            raise ValueError("event_samples must contain integer sample indices.")
-        return events.astype(np.int64, copy=True)
+        try:
+            return cls._as_int64(events, "event_samples")
+        except ValueError as error:
+            if "one-dimensional" in str(error) or "signed 64-bit" in str(error):
+                raise
+            raise ValueError(
+                "event_samples must contain integer sample indices."
+            ) from error
 
     @staticmethod
     def _validate_window(
         window: tuple[int | float, int | float],
-    ) -> tuple[float, float]:
+    ) -> tuple[int | float, int | float]:
         """Validate a two-boundary finite window."""
-        values = np.asarray(window)
-        if values.shape != (2,) or not np.issubdtype(values.dtype, np.number):
+        values = np.asarray(window, dtype=object)
+        if values.shape != (2,):
             raise ValueError("window must contain exactly two numeric boundaries.")
-        if not np.all(np.isfinite(values)):
-            raise ValueError("window boundaries must be finite.")
-        start, stop = (float(values[0]), float(values[1]))
+        normalized: list[int | float] = []
+        for value in values.tolist():
+            if isinstance(value, (bool, np.bool_)) or not isinstance(
+                value, (int, float, np.integer, np.floating)
+            ):
+                raise ValueError("window must contain exactly two numeric boundaries.")
+            if isinstance(value, (float, np.floating)) and not np.isfinite(value):
+                raise ValueError("window boundaries must be finite.")
+            normalized.append(
+                int(value) if isinstance(value, (int, np.integer)) else float(value)
+            )
+        start, stop = normalized
         if start >= stop:
             raise ValueError("window start must be strictly less than window stop.")
         return start, stop
@@ -185,23 +231,34 @@ class CycleAverageBias(LinearDenoiser):
 
     @staticmethod
     def _window_to_samples(
-        window: tuple[float, float],
+        window: tuple[int | float, int | float],
         *,
         window_unit: Literal["samples", "seconds"],
         sfreq: float | None,
     ) -> tuple[int, int]:
         """Convert a validated interval to integer sample boundaries once."""
-        values = np.asarray(window)
         if window_unit == "samples":
-            if not np.all(values == np.rint(values)):
+            try:
+                samples = CycleAverageBias._as_int64(window, "window boundaries")
+            except ValueError as error:
+                if "signed 64-bit" in str(error):
+                    raise
                 raise ValueError(
                     "window boundaries must be integers when window_unit='samples'."
-                )
-            samples = np.rint(values).astype(int)
+                ) from error
         else:
             # _validate_sfreq guarantees this for the seconds pathway.
             assert sfreq is not None
-            samples = np.rint(values * sfreq).astype(int)
+            rounded: list[int] = []
+            for boundary in window:
+                scaled = float(boundary) * sfreq
+                if not np.isfinite(scaled):
+                    raise ValueError(
+                        "window boundaries in seconds resolve outside the finite "
+                        "sample range."
+                    )
+                rounded.append(round(scaled))
+            samples = CycleAverageBias._as_int64(rounded, "window boundaries")
         if samples[0] >= samples[1]:
             raise ValueError(
                 "window resolves to an empty or reversed sample interval; "
@@ -246,7 +303,11 @@ class CycleAverageBias(LinearDenoiser):
             return None
         if not isinstance(first_samp, int | np.integer) or isinstance(first_samp, bool):
             raise TypeError("first_samp must be an integer.")
-        return int(first_samp)
+        value = int(first_samp)
+        bounds = np.iinfo(np.int64)
+        if value < int(bounds.min) or value > int(bounds.max):
+            raise ValueError("first_samp must fit in signed 64-bit samples.")
+        return value
 
     def apply(self, data: np.ndarray) -> np.ndarray:
         """Apply cycle averaging bias.
@@ -278,10 +339,18 @@ class CycleAverageBias(LinearDenoiser):
 
         # Filter valid events (within data bounds)
         pre, post = self.window
-        valid_mask = (self.event_samples_data_ + pre >= 0) & (
-            self.event_samples_data_ + post <= total_samples
+        # Compare before adding the window offsets so extreme, invalid event
+        # coordinates cannot wrap around signed int64 and appear valid.
+        minimum_event = -pre
+        maximum_event = total_samples - post
+        valid_events = np.asarray(
+            [
+                int(event)
+                for event in self.event_samples_data_
+                if minimum_event <= int(event) <= maximum_event
+            ],
+            dtype=np.int64,
         )
-        valid_events = self.event_samples_data_[valid_mask]
 
         if len(valid_events) == 0:
             # No valid events, return zeros (no artifact signal)

--- a/mne_denoise/dss/denoisers/temporal.py
+++ b/mne_denoise/dss/denoisers/temporal.py
@@ -1,7 +1,7 @@
 """Temporal bias functions for DSS.
 
-Implements time-shift and smoothing biases for extracting temporally
-extended structure (slow waves, autocorrelated signals).
+Implements lag-averaging and smoothing biases for extracting temporally
+predictable structure (slow waves and autocorrelated signals).
 
 Authors: Sina Esmaeili (sina.esmaeili@umontreal.ca)
          Hamza Abdelhedi (hamza.abdelhedi@umontreal.ca)
@@ -20,16 +20,21 @@ References
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 
 from .base import LinearDenoiser, NonlinearDenoiser
 
 
-class TimeShiftBias(LinearDenoiser):
-    """Time-shift bias for extracting autocorrelated signals.
+class LagAveragingBias(LinearDenoiser):
+    """Lag-averaging bias for extracting autocorrelated signals.
 
     Creates a bias by averaging time-shifted versions of the data,
-    emphasizing signals that are predictable across time lags.
+    emphasizing signals that are predictable across time lags. This is a
+    bias-side temporal averaging operator that still yields an ordinary
+    spatial DSS filter. It is not the data-side lag augmentation used by true
+    time-shift DSS (``TimeShiftDSS``), which is not yet implemented.
 
     Parameters
     ----------
@@ -44,7 +49,7 @@ class TimeShiftBias(LinearDenoiser):
 
     Examples
     --------
-    >>> bias = TimeShiftBias(shifts=[1, 2, 5, 10], method="prediction")
+    >>> bias = LagAveragingBias(shifts=[1, 2, 5, 10], method="prediction")
     >>> biased_data = bias.apply(data)
 
     See Also
@@ -59,15 +64,40 @@ class TimeShiftBias(LinearDenoiser):
     ) -> None:
         self.shifts = shifts
         self.method = method
+        self._shift_array = self._validate_shifts(shifts)
 
-        # Resolve shifts to array
-        if isinstance(shifts, int):
-            self._shift_array = np.arange(1, shifts + 1)
-        else:
-            self._shift_array = np.asarray(shifts)
+        if method not in {"autocorrelation", "prediction"}:
+            raise ValueError(
+                f"method must be 'autocorrelation' or 'prediction', got {method!r}."
+            )
+
+    @staticmethod
+    def _validate_shifts(shifts: int | np.ndarray) -> np.ndarray:
+        """Resolve lag specifications to a non-empty integer array."""
+        if isinstance(shifts, int | np.integer) and not isinstance(shifts, bool):
+            if int(shifts) < 1:
+                raise ValueError("shifts must be a positive integer.")
+            return np.arange(1, int(shifts) + 1)
+
+        shift_array = np.asarray(shifts)
+        if shift_array.ndim != 1 or shift_array.size == 0:
+            raise ValueError("shifts must be a non-empty one-dimensional array.")
+        if not np.issubdtype(shift_array.dtype, np.number) or not np.all(
+            np.isfinite(shift_array)
+        ):
+            raise ValueError("shifts must contain only finite integer samples.")
+        if not np.all(shift_array == np.rint(shift_array)):
+            raise ValueError("shifts must contain integer sample offsets.")
+
+        shift_array = shift_array.astype(int, copy=False)
+        if np.any(shift_array == 0):
+            raise ValueError("shifts cannot contain zero.")
+        if np.unique(shift_array).size != shift_array.size:
+            raise ValueError("shifts cannot contain duplicate sample offsets.")
+        return shift_array
 
     def apply(self, data: np.ndarray) -> np.ndarray:
-        """Apply time-shift bias.
+        """Apply lag-averaging bias.
 
         Parameters
         ----------
@@ -77,44 +107,47 @@ class TimeShiftBias(LinearDenoiser):
         Returns
         -------
         biased : ndarray, same shape as input
-            Time-shifted averaged data.
+            Lag-averaged data.
         """
-        # Handle 3D data
-        orig_shape = data.shape
+        data = np.asarray(data)
+        if data.ndim not in (2, 3):
+            raise ValueError(f"Data must be 2D or 3D, got {data.ndim}D")
+
+        # Epochs are independent observations. Applying the bias separately
+        # prevents a shifted value from one epoch leaking into its neighbour.
         if data.ndim == 3:
-            n_ch, n_times, n_epochs = data.shape
-            data_2d = data.reshape(n_ch, -1)
-        else:
-            data_2d = data
+            biased = np.empty_like(data, dtype=np.result_type(data.dtype, float))
+            for epoch in range(data.shape[2]):
+                biased[:, :, epoch] = self._apply_2d(data[:, :, epoch])
+            return biased
 
-        if self.method == "autocorrelation":
-            biased_2d = self._autocorrelation_bias(data_2d)
-        elif self.method == "prediction":
-            biased_2d = self._prediction_bias(data_2d)
-        else:
-            raise ValueError(f"Unknown method: {self.method}")
+        return self._apply_2d(data)
 
-        # Restore shape
-        if data.ndim == 3:
-            return biased_2d.reshape(orig_shape)
-        return biased_2d
-
-    def _autocorrelation_bias(self, data: np.ndarray) -> np.ndarray:
-        """Average of time-shifted versions."""
-        n_channels, n_samples = data.shape
-        shifts = self._shift_array
-        max_shift = np.max(np.abs(shifts))
-
+    def _apply_2d(self, data: np.ndarray) -> np.ndarray:
+        """Apply the configured lag average to one continuous array."""
+        max_shift = int(np.max(np.abs(self._shift_array)))
+        n_samples = data.shape[1]
         if max_shift >= n_samples // 2:
             raise ValueError(
                 f"Max shift ({max_shift}) too large for data length ({n_samples})"
             )
 
+        if self.method == "autocorrelation":
+            return self._autocorrelation_bias(data)
+        return self._prediction_bias(data)
+
+    def _autocorrelation_bias(self, data: np.ndarray) -> np.ndarray:
+        """Average of time-shifted versions."""
+        n_channels, n_samples = data.shape
+        shifts = self._shift_array
+        max_shift = int(np.max(np.abs(shifts)))
+
         valid_start = max_shift
         valid_end = n_samples - max_shift
         valid_length = valid_end - valid_start
 
-        accumulated = np.zeros((n_channels, valid_length))
+        dtype = np.result_type(data.dtype, float)
+        accumulated = np.zeros((n_channels, valid_length), dtype=dtype)
         for shift in shifts:
             shifted = data[:, valid_start + shift : valid_end + shift]
             accumulated += shifted
@@ -122,7 +155,7 @@ class TimeShiftBias(LinearDenoiser):
         biased = accumulated / len(shifts)
 
         # Pad to original length
-        biased_full = np.zeros_like(data)
+        biased_full = np.zeros_like(data, dtype=dtype)
         biased_full[:, valid_start:valid_end] = biased
         return biased_full
 
@@ -130,14 +163,15 @@ class TimeShiftBias(LinearDenoiser):
         """Weighted average (closer lags weighted more)."""
         n_channels, n_samples = data.shape
         shifts = self._shift_array
-        max_shift = np.max(np.abs(shifts))
+        max_shift = int(np.max(np.abs(shifts)))
 
         valid_start = max_shift
         valid_end = n_samples - max_shift
         valid_length = valid_end - valid_start
 
-        accumulated = np.zeros((n_channels, valid_length))
-        total_weight = 0
+        dtype = np.result_type(data.dtype, float)
+        accumulated = np.zeros((n_channels, valid_length), dtype=dtype)
+        total_weight = 0.0
 
         for shift in shifts:
             weight = 1.0 / max(abs(shift), 1)
@@ -147,9 +181,34 @@ class TimeShiftBias(LinearDenoiser):
 
         biased = accumulated / total_weight
 
-        biased_full = np.zeros_like(data)
+        biased_full = np.zeros_like(data, dtype=dtype)
         biased_full[:, valid_start:valid_end] = biased
         return biased_full
+
+
+class TimeShiftBias(LagAveragingBias):
+    """Deprecated compatibility name for :class:`LagAveragingBias`.
+
+    The released 0.x implementation performs bias-side lag averaging, not the
+    data-side lag augmentation denoted by time-shift DSS. The implementation
+    and numerical behavior are unchanged; only the mechanically accurate name
+    is canonical.
+    """
+
+    def __init__(
+        self,
+        shifts: int | np.ndarray = 10,
+        method: str = "autocorrelation",
+    ) -> None:
+        warnings.warn(
+            "'TimeShiftBias' is deprecated and will be removed in "
+            "mne-denoise 1.0; use 'LagAveragingBias' instead. True "
+            "TimeShiftDSS is reserved for a future data-side lag-augmented "
+            "implementation.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        super().__init__(shifts=shifts, method=method)
 
 
 class SmoothingBias(LinearDenoiser):
@@ -158,7 +217,7 @@ class SmoothingBias(LinearDenoiser):
     Uses a boxcar moving average filter to smooth the data. When used to split
     the signal into a smooth branch and a residual (``data - smooth``), fitting
     DSS on the residual and adding the smooth branch back follows ZapLine's
-    period-matched decomposition (de Cheveigné, 2020 [3]_): with
+    period-matched decomposition (de Cheveigné, 2020): with
     ``window = round(sfreq / f_line)`` the smoother has zeros at ``f_line`` and
     its harmonics, so the residual concentrates the narrowband artifact.
 

--- a/mne_denoise/dss/variants/__init__.py
+++ b/mne_denoise/dss/variants/__init__.py
@@ -1,16 +1,17 @@
 """DSS Variants and Applications.
 
 Contains specialized implementations of DSS for specific tasks:
-- TSR: Time-Shift DSS for temporal structure
+- Lag-averaging DSS for temporal structure
 - SSVEP: SSVEP enhancement using comb filters
 - Narrowband: Frequency scanning and band-specific extraction
 """
 
 from .narrowband import narrowband_dss, narrowband_scan
 from .ssvep import ssvep_dss
-from .tsr import smooth_dss, time_shift_dss
+from .tsr import lag_averaging_dss, smooth_dss, time_shift_dss
 
 __all__ = [
+    "lag_averaging_dss",
     "time_shift_dss",
     "smooth_dss",
     "ssvep_dss",

--- a/mne_denoise/dss/variants/tsr.py
+++ b/mne_denoise/dss/variants/tsr.py
@@ -1,7 +1,9 @@
-"""Time-Shift DSS (TSR) variant.
+"""Lag-averaging and smoothing DSS convenience constructors.
 
-Convenience wrapper for extracting temporally extended structure
-(autocorrelated signals, slow waves, DC shifts) [1]_.
+These bias-side temporal operators extract autocorrelated signals, slow waves,
+and DC shifts. They do not implement the data-side lag augmentation of true
+time-shift DSS [1]_; the ``TimeShiftDSS`` name is reserved for that future
+estimator.
 
 Authors: Sina Esmaeili (sina.esmaeili@umontreal.ca)
          Hamza Abdelhedi (hamza.abdelhedi@umontreal.ca)
@@ -14,23 +16,26 @@ References
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 
-from ..denoisers.temporal import SmoothingBias, TimeShiftBias
+from ..denoisers.temporal import LagAveragingBias, SmoothingBias
 from ..linear import DSS
 
 
-def time_shift_dss(
+def lag_averaging_dss(
     shifts: int | np.ndarray = 10,
     *,
     method: str = "autocorrelation",
     n_components: int | None = None,
     **dss_kws,
 ) -> DSS:
-    """Create a DSS configured for temporal predictability.
+    """Create a DSS configured with a bias-side lag average.
 
     Returns a pre-configured DSS object that extracts components with
-    high autocorrelation (temporally smooth or predictable signals).
+    high lag predictability. The resulting filter is spatial DSS; this helper
+    does not construct data-side lag-augmented filters.
 
     Parameters
     ----------
@@ -50,21 +55,49 @@ def time_shift_dss(
     Returns
     -------
     dss : DSS
-        A DSS object configured with a TimeShiftBias.
+        A DSS object configured with a :class:`LagAveragingBias`.
 
     Examples
     --------
     >>> # Extract temporally predictable components
-    >>> dss = time_shift_dss(shifts=20)
+    >>> dss = lag_averaging_dss(shifts=20)
     >>> dss.fit(data)
     >>> slow_sources = dss.transform(data)
 
     >>> # Use specific lags
-    >>> dss = time_shift_dss(shifts=np.array([1, 2, 5, 10, 20]))
+    >>> dss = lag_averaging_dss(shifts=np.array([1, 2, 5, 10, 20]))
     >>> dss.fit(data)
     """
-    bias = TimeShiftBias(shifts=shifts, method=method)
+    bias = LagAveragingBias(shifts=shifts, method=method)
     return DSS(bias=bias, n_components=n_components, **dss_kws)
+
+
+def time_shift_dss(
+    shifts: int | np.ndarray = 10,
+    *,
+    method: str = "autocorrelation",
+    n_components: int | None = None,
+    **dss_kws,
+) -> DSS:
+    """Construct lag-averaging DSS through its deprecated compatibility name.
+
+    The released helper configures bias-side lag averaging rather than true
+    time-shift DSS. Its 0.x numerical behavior is retained under the canonical
+    name while this compatibility wrapper emits ``FutureWarning``.
+    """
+    warnings.warn(
+        "'time_shift_dss' is deprecated and will be removed in mne-denoise "
+        "1.0; use 'lag_averaging_dss' instead. The 'TimeShiftDSS' name is "
+        "reserved for a future data-side lag-augmented implementation.",
+        FutureWarning,
+        stacklevel=2,
+    )
+    return lag_averaging_dss(
+        shifts=shifts,
+        method=method,
+        n_components=n_components,
+        **dss_kws,
+    )
 
 
 def smooth_dss(

--- a/tests/denoisers/test_artifact.py
+++ b/tests/denoisers/test_artifact.py
@@ -293,6 +293,72 @@ def test_cycle_average_rejects_noninteger_or_nonvector_events(events):
         )
 
 
+@pytest.mark.parametrize(
+    "events",
+    [
+        np.array([2**63], dtype=np.uint64),
+        [2**63],
+        [-(2**63) - 1],
+    ],
+)
+def test_cycle_average_rejects_event_coordinates_outside_int64(events):
+    """Event conversion rejects values that would wrap signed sample indices."""
+    with pytest.raises(ValueError, match="signed 64-bit"):
+        CycleAverageBias(
+            event_samples=events,
+            window=(-1, 2),
+            window_unit="samples",
+            event_origin="data",
+        )
+
+
+def test_cycle_average_extreme_int64_events_remain_invalid_without_wraparound():
+    """Extreme signed events cannot overflow into the valid data interval."""
+    bounds = np.iinfo(np.int64)
+    bias = CycleAverageBias(
+        event_samples=np.array([bounds.min, bounds.max], dtype=np.int64),
+        window=(-1, 2),
+        window_unit="samples",
+        event_origin="data",
+    )
+
+    observed = bias.apply(np.ones((2, 16)))
+
+    assert_allclose(observed, 0)
+
+
+@pytest.mark.parametrize(
+    "window, unit, sfreq",
+    [
+        ((-(2**63) - 1, 1), "samples", None),
+        ((-1, 2**63), "samples", None),
+        ((-1e308, 1e308), "seconds", 1e308),
+    ],
+)
+def test_cycle_average_rejects_window_sample_overflow(window, unit, sfreq):
+    """Window conversion fails explicitly instead of wrapping through int64."""
+    with pytest.raises(ValueError, match="sample range|signed 64-bit"):
+        CycleAverageBias(
+            event_samples=[4],
+            window=window,
+            window_unit=unit,
+            sfreq=sfreq,
+            event_origin="data",
+        )
+
+
+def test_cycle_average_rejects_raw_origin_subtraction_overflow():
+    """Mapping acquisition events to data coordinates is exact and range-safe."""
+    with pytest.raises(ValueError, match="signed 64-bit"):
+        CycleAverageBias(
+            event_samples=[np.iinfo(np.int64).min],
+            window=(-1, 2),
+            window_unit="samples",
+            event_origin="raw",
+            first_samp=1,
+        )
+
+
 def test_cycle_average_3d_concatenation_is_epoch_major():
     """Concatenated event coordinates traverse complete epochs in order."""
     data = np.zeros((1, 6, 2))

--- a/tests/denoisers/test_artifact.py
+++ b/tests/denoisers/test_artifact.py
@@ -1,6 +1,7 @@
 """Unit tests for artifact denoisers (CycleAverageBias)."""
 
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 
 from mne_denoise.dss.denoisers.artifact import CycleAverageBias
@@ -33,7 +34,12 @@ def test_cycle_average_bias():
 
     # 3. Apply CycleAverageBias
     window = (-25, 25)
-    bias = CycleAverageBias(event_samples=events, window=window)
+    bias = CycleAverageBias(
+        event_samples=events,
+        window=window,
+        window_unit="samples",
+        event_origin="data",
+    )
     biased_data = bias.apply(data)
 
     # 4. Verification
@@ -71,9 +77,17 @@ def test_cycle_average_bias_sfreq():
     sfreq = 100.0
 
     # Window: -0.1s to +0.2s -> -10 to +20 samples
-    bias = CycleAverageBias(event_samples=events, window=(-0.1, 0.2), sfreq=sfreq)
+    bias = CycleAverageBias(
+        event_samples=events,
+        window=(-0.1, 0.2),
+        window_unit="seconds",
+        sfreq=sfreq,
+        event_origin="data",
+    )
 
     assert bias.window == (-10, 20)
+    assert bias.window_input == (-0.1, 0.2)
+    assert bias.window_unit == "seconds"
 
 
 def test_cycle_average_bias_3d_data():
@@ -87,7 +101,12 @@ def test_cycle_average_bias_3d_data():
     # Add a periodic artifact at known locations
     events = np.array([20, 50, 80])  # Within first epoch
 
-    bias = CycleAverageBias(event_samples=events, window=(-5, 5))
+    bias = CycleAverageBias(
+        event_samples=events,
+        window=(-5, 5),
+        window_unit="samples",
+        event_origin="data",
+    )
     biased = bias.apply(data)
 
     # Output should be 3D with same shape
@@ -104,7 +123,12 @@ def test_cycle_average_bias_empty_events():
     # Events outside data bounds
     events = np.array([1000, 2000])  # Way outside
 
-    bias = CycleAverageBias(event_samples=events, window=(-10, 10))
+    bias = CycleAverageBias(
+        event_samples=events,
+        window=(-10, 10),
+        window_unit="samples",
+        event_origin="data",
+    )
     biased = bias.apply(data)
 
     # Should return zeros when no valid events
@@ -114,10 +138,13 @@ def test_cycle_average_bias_empty_events():
 
 def test_cycle_average_bias_invalid_ndim():
     """Test CycleAverageBias raises error for invalid dimensions."""
-    import pytest
-
     events = [50]
-    bias = CycleAverageBias(event_samples=events, window=(-5, 5))
+    bias = CycleAverageBias(
+        event_samples=events,
+        window=(-5, 5),
+        window_unit="samples",
+        event_origin="data",
+    )
 
     # 1D data should raise ValueError
     data_1d = np.array([1, 2, 3, 4, 5])
@@ -134,10 +161,152 @@ def test_cycle_average_bias_partial_valid_events():
     # Mix of valid and invalid events (some at edges)
     events = np.array([5, 50, 100, 195])  # 5 and 195 may be clipped by window
 
-    bias = CycleAverageBias(event_samples=events, window=(-10, 10))
+    bias = CycleAverageBias(
+        event_samples=events,
+        window=(-10, 10),
+        window_unit="samples",
+        event_origin="data",
+    )
     biased = bias.apply(data)
 
     # Should still work with the valid events in the middle
     assert biased.shape == data.shape
     # Middle event (50) window should be non-zero
     assert np.any(biased[:, 40:60] != 0)
+
+
+@pytest.mark.parametrize(
+    "sfreq, expected_unit, expected_window",
+    [
+        (None, "samples", (-1, 2)),
+        (10.0, "seconds", (-10, 20)),
+    ],
+)
+def test_cycle_average_legacy_unit_inference(sfreq, expected_unit, expected_window):
+    """Released implicit units warn and retain their 0.x conversion."""
+    with pytest.warns(FutureWarning) as records:
+        bias = CycleAverageBias(event_samples=[20], window=(-1, 2), sfreq=sfreq)
+
+    messages = [str(record.message) for record in records]
+    assert any("window_unit" in message for message in messages)
+    assert any("event_origin" in message for message in messages)
+    assert bias.window_unit == expected_unit
+    assert bias.event_origin == "data"
+    assert bias.window == expected_window
+
+
+def test_cycle_average_seconds_use_documented_nearest_sample_rounding():
+    """Second boundaries are converted once using NumPy nearest rounding."""
+    bias = CycleAverageBias(
+        event_samples=[20],
+        window=(-0.015, 0.015),
+        window_unit="seconds",
+        sfreq=100.0,
+        event_origin="data",
+    )
+
+    assert bias.window == (-2, 2)
+
+
+def test_cycle_average_raw_event_origin_subtracts_first_samp_once():
+    """MNE acquisition samples map to data coordinates exactly once."""
+    data = np.arange(40.0)[np.newaxis, :]
+    raw_numbered_event = 1_020
+    bias = CycleAverageBias(
+        event_samples=[raw_numbered_event],
+        window=(-2, 3),
+        window_unit="samples",
+        event_origin="raw",
+        first_samp=1_000,
+    )
+
+    first = bias.apply(data)
+    second = bias.apply(data)
+
+    assert bias.event_samples.tolist() == [raw_numbered_event]
+    assert bias.event_offset_samples_ == 1_000
+    assert bias.event_samples_data_.tolist() == [20]
+    assert_allclose(first, second)
+    assert_allclose(first[:, 18:23], data[:, 18:23])
+    assert np.count_nonzero(first) == 5
+
+
+def test_cycle_average_data_origin_does_not_accept_offset():
+    """An offset cannot be accidentally applied to data-relative events."""
+    with pytest.raises(ValueError, match="must be omitted"):
+        CycleAverageBias(
+            event_samples=[20],
+            window=(-2, 3),
+            window_unit="samples",
+            event_origin="data",
+            first_samp=1_000,
+        )
+
+
+def test_cycle_average_raw_origin_requires_first_samp():
+    """Raw-numbered events require an explicit MNE first sample."""
+    with pytest.raises(ValueError, match="first_samp is required"):
+        CycleAverageBias(
+            event_samples=[20],
+            window=(-2, 3),
+            window_unit="samples",
+            event_origin="raw",
+        )
+
+
+def test_cycle_average_rejects_unknown_event_origin():
+    """Only data-relative and MNE Raw acquisition coordinates are supported."""
+    with pytest.raises(ValueError, match="event_origin"):
+        CycleAverageBias(
+            event_samples=[20],
+            window=(-2, 3),
+            window_unit="samples",
+            event_origin="epochs",
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        ({"window": (-1.5, 2), "window_unit": "samples"}, "integers"),
+        ({"window": (-1, 2), "window_unit": "seconds"}, "sfreq is required"),
+        ({"window": (2, -1), "window_unit": "samples"}, "strictly less"),
+        ({"window": (-1, 2), "window_unit": "minutes"}, "window_unit"),
+        ({"window": (-1, 2), "window_unit": "samples", "sfreq": 0}, "positive"),
+    ],
+)
+def test_cycle_average_rejects_ambiguous_window_contracts(kwargs, match):
+    """Invalid or ambiguous window contracts fail before data processing."""
+    with pytest.raises(ValueError, match=match):
+        CycleAverageBias(event_samples=[20], event_origin="data", **kwargs)
+
+
+@pytest.mark.parametrize("events", [[1.5], [[1, 2]], [np.nan]])
+def test_cycle_average_rejects_noninteger_or_nonvector_events(events):
+    """Event positions are a finite one-dimensional integer sequence."""
+    with pytest.raises(ValueError, match="event_samples"):
+        CycleAverageBias(
+            event_samples=events,
+            window=(-1, 2),
+            window_unit="samples",
+            event_origin="data",
+        )
+
+
+def test_cycle_average_3d_concatenation_is_epoch_major():
+    """Concatenated event coordinates traverse complete epochs in order."""
+    data = np.zeros((1, 6, 2))
+    data[0, :, 0] = np.arange(1, 7)
+    data[0, :, 1] = np.arange(101, 107)
+    bias = CycleAverageBias(
+        event_samples=[2, 8],
+        window=(-1, 2),
+        window_unit="samples",
+        event_origin="data",
+    )
+
+    observed = bias.apply(data)
+
+    expected_template = np.array([52.0, 53.0, 54.0])
+    assert_allclose(observed[0, 1:4, 0], expected_template)
+    assert_allclose(observed[0, 1:4, 1], expected_template)

--- a/tests/denoisers/test_temporal.py
+++ b/tests/denoisers/test_temporal.py
@@ -1,104 +1,101 @@
-"""Unit tests for temporal denoisers (TimeShiftBias, SmoothingBias)."""
+"""Unit tests for lag-averaging and smoothing denoisers."""
 
 import numpy as np
 import pytest
 
 from mne_denoise.dss.denoisers.temporal import (
     DCTDenoiser,
+    LagAveragingBias,
     SmoothingBias,
     TimeShiftBias,
 )
 
 
-def test_timeshift_basic_2d():
-    """Test TimeShiftBias with 2D data."""
+def test_lag_averaging_basic_2d():
+    """Test LagAveragingBias with 2D data."""
     rng = np.random.default_rng(42)
     n_ch, n_times = 3, 200
     data = rng.normal(0, 1, (n_ch, n_times))
 
-    bias = TimeShiftBias(shifts=5)
+    bias = LagAveragingBias(shifts=5)
     biased = bias.apply(data)
 
     assert biased.shape == data.shape
 
 
-def test_timeshift_basic_3d():
-    """Test TimeShiftBias with 3D epoched data."""
+def test_lag_averaging_basic_3d():
+    """Test LagAveragingBias with 3D epoched data."""
     rng = np.random.default_rng(42)
     n_ch, n_times, n_epochs = 3, 200, 4
     data = rng.normal(0, 1, (n_ch, n_times, n_epochs))
 
-    bias = TimeShiftBias(shifts=5)
+    bias = LagAveragingBias(shifts=5)
     biased = bias.apply(data)
 
     assert biased.shape == data.shape
     assert biased.ndim == 3
 
 
-def test_shifts_as_array():
-    """Test TimeShiftBias with shifts specified as array."""
+def test_lag_averaging_shifts_as_array():
+    """Test LagAveragingBias with shifts specified as an array."""
     rng = np.random.default_rng(42)
     data = rng.normal(0, 1, (2, 100))
 
     shifts = np.array([1, 2, 5, 10])
-    bias = TimeShiftBias(shifts=shifts)
+    bias = LagAveragingBias(shifts=shifts)
     biased = bias.apply(data)
 
     assert biased.shape == data.shape
 
 
-def test_autocorrelation_method():
-    """Test TimeShiftBias with autocorrelation method."""
+def test_lag_averaging_autocorrelation_method():
+    """Test LagAveragingBias with the autocorrelation method."""
     rng = np.random.default_rng(42)
     data = rng.normal(0, 1, (2, 100))
 
-    bias = TimeShiftBias(shifts=5, method="autocorrelation")
+    bias = LagAveragingBias(shifts=5, method="autocorrelation")
     biased = bias.apply(data)
 
     assert biased.shape == data.shape
 
 
-def test_prediction_method():
-    """Test TimeShiftBias with prediction method."""
+def test_lag_averaging_prediction_method():
+    """Test LagAveragingBias with the prediction method."""
     rng = np.random.default_rng(42)
     data = rng.normal(0, 1, (2, 100))
 
-    bias = TimeShiftBias(shifts=5, method="prediction")
+    bias = LagAveragingBias(shifts=5, method="prediction")
     biased = bias.apply(data)
 
     assert biased.shape == data.shape
 
 
-def test_unknown_method_error():
-    """Test TimeShiftBias raises error for unknown method."""
-    rng = np.random.default_rng(42)
-    data = rng.normal(0, 1, (2, 100))
-
-    bias = TimeShiftBias(shifts=5, method="unknown")
-    with pytest.raises(ValueError, match="Unknown method"):
-        bias.apply(data)
+def test_lag_averaging_unknown_method_error():
+    """Reject an unknown lag-averaging method at construction."""
+    with pytest.raises(ValueError, match="method must be"):
+        LagAveragingBias(shifts=5, method="unknown")
 
 
-def test_shift_too_large_error():
-    """Test TimeShiftBias raises error when shift too large."""
+def test_lag_averaging_shift_too_large_error():
+    """Test LagAveragingBias raises when a shift is too large."""
     data = np.ones((2, 20))
 
-    bias = TimeShiftBias(shifts=15)  # Too large for data length 20
+    bias = LagAveragingBias(shifts=15)  # Too large for data length 20
     with pytest.raises(ValueError, match="too large"):
         bias.apply(data)
 
 
-def test_data_too_short_error():
-    """Test TimeShiftBias raises error when data too short."""
+def test_lag_averaging_data_too_short_error():
+    """Test LagAveragingBias raises when data are too short."""
     data = np.ones((2, 10))
 
-    bias = TimeShiftBias(shifts=5)
+    bias = LagAveragingBias(shifts=5)
     with pytest.raises(ValueError, match="too short|too large"):
         bias.apply(data)
 
 
-def test_autocorrelated_signal_preserved():
-    """Test TimeShiftBias preserves autocorrelated signals."""
+def test_lag_averaging_preserves_autocorrelated_signal():
+    """Test LagAveragingBias preserves autocorrelated signals."""
     n_times = 500
     times = np.arange(n_times) / 100
 
@@ -111,7 +108,7 @@ def test_autocorrelated_signal_preserved():
 
     data = (slow_signal + fast_noise)[np.newaxis, :]
 
-    bias = TimeShiftBias(shifts=10)
+    bias = LagAveragingBias(shifts=10)
     biased = bias.apply(data)
 
     # Slow signal should be better correlated with biased output
@@ -119,6 +116,53 @@ def test_autocorrelated_signal_preserved():
     center = slice(50, -50)
     corr = np.corrcoef(biased[0, center], slow_signal[center])[0, 1]
     assert corr > 0.9, f"Autocorrelated signal should be preserved (corr={corr:.3f})"
+
+
+@pytest.mark.parametrize(
+    "shifts, match",
+    [
+        (0, "positive"),
+        ([], "non-empty"),
+        ([1, 1], "duplicate"),
+        ([0, 1], "zero"),
+        ([1.5], "integer"),
+    ],
+)
+def test_lag_averaging_rejects_ambiguous_shifts(shifts, match):
+    """Lag specifications are finite, unique, non-zero integer samples."""
+    with pytest.raises(ValueError, match=match):
+        LagAveragingBias(shifts=shifts)
+
+
+def test_lag_averaging_epochs_are_independent():
+    """Lag averaging does not carry samples across epoch boundaries."""
+    data = np.zeros((1, 20, 2))
+    data[:, :, 0] = 1.0
+    data[:, :, 1] = 100.0
+    bias = LagAveragingBias(shifts=2)
+
+    observed = bias.apply(data)
+
+    for epoch in range(data.shape[2]):
+        expected = bias.apply(data[:, :, epoch])
+        np.testing.assert_allclose(observed[:, :, epoch], expected)
+
+
+def test_time_shift_bias_compatibility_warning_and_parity():
+    """The released name warns while retaining lag-average numerics."""
+    data = np.arange(40.0).reshape(2, 20)
+    canonical = LagAveragingBias(shifts=[-2, 1], method="prediction")
+    with pytest.warns(FutureWarning, match="LagAveragingBias"):
+        legacy = TimeShiftBias(shifts=[-2, 1], method="prediction")
+
+    np.testing.assert_allclose(legacy.apply(data), canonical.apply(data))
+
+
+def test_time_shift_dss_name_is_reserved_not_exported():
+    """This rename does not claim a true lag-augmented estimator exists."""
+    import mne_denoise.dss as dss_module
+
+    assert not hasattr(dss_module, "TimeShiftDSS")
 
 
 def test_smoothing_basic_2d():

--- a/tests/variants/test_tsr.py
+++ b/tests/variants/test_tsr.py
@@ -2,8 +2,12 @@ import mne
 import numpy as np
 import pytest
 
-from mne_denoise.dss.denoisers.temporal import SmoothingBias, TimeShiftBias
-from mne_denoise.dss.variants.tsr import smooth_dss, time_shift_dss
+from mne_denoise.dss.denoisers.temporal import LagAveragingBias, SmoothingBias
+from mne_denoise.dss.variants.tsr import (
+    lag_averaging_dss,
+    smooth_dss,
+    time_shift_dss,
+)
 
 
 @pytest.fixture
@@ -32,7 +36,7 @@ def slow_data_generator():
 
 def test_tsr_array(slow_data_generator):
     data, slow = slow_data_generator((3, 500))
-    dss = time_shift_dss(shifts=10, n_components=3)
+    dss = lag_averaging_dss(shifts=10, n_components=3)
     dss.fit(data)
 
     sources = dss.transform(data)
@@ -46,7 +50,7 @@ def test_tsr_raw(slow_data_generator):
     info = mne.create_info(3, 100, "eeg")
     raw = mne.io.RawArray(data, info, verbose=False)
 
-    dss = time_shift_dss(shifts=10, n_components=3)
+    dss = lag_averaging_dss(shifts=10, n_components=3)
     dss.fit(raw)
 
     sources = dss.transform(raw)
@@ -59,7 +63,7 @@ def test_tsr_epochs(slow_data_generator):
     info = mne.create_info(3, 100, "eeg")
     epochs = mne.EpochsArray(data, info, verbose=False)
 
-    dss = time_shift_dss(shifts=10, n_components=2)
+    dss = lag_averaging_dss(shifts=10, n_components=2)
     dss.fit(epochs)
 
     sources = dss.transform(epochs)
@@ -92,8 +96,8 @@ def test_tsr_3d_bias_unit():
     rng = np.random.default_rng(42)
     data_3d = rng.standard_normal((3, 20, 5))  # (ch, times, epochs)
 
-    # 1. TimeShiftBias
-    bias = TimeShiftBias(shifts=2)
+    # 1. LagAveragingBias
+    bias = LagAveragingBias(shifts=2)
     out_3d = bias.apply(data_3d)
     assert out_3d.shape == data_3d.shape
     assert out_3d.ndim == 3
@@ -109,10 +113,31 @@ def test_tsr_prediction_method(slow_data_generator):
     """Test functionality of prediction method."""
     data, slow = slow_data_generator((3, 500))
 
-    dss = time_shift_dss(shifts=10, method="prediction", n_components=3)
+    dss = lag_averaging_dss(shifts=10, method="prediction", n_components=3)
     dss.fit(data)
 
     sources = dss.transform(data)
     # Should still extract the slow component
     corr = np.abs(np.corrcoef(sources[0], slow)[0, 1])
     assert corr > 0.8
+
+
+def test_time_shift_dss_compatibility_warning_and_parity():
+    """The old helper warns and still returns the canonical configuration."""
+    with pytest.warns(FutureWarning, match="lag_averaging_dss"):
+        legacy = time_shift_dss(shifts=[1, 3], method="prediction", n_components=2)
+    canonical = lag_averaging_dss(shifts=[1, 3], method="prediction", n_components=2)
+
+    assert isinstance(legacy.bias, LagAveragingBias)
+    assert legacy.bias.method == canonical.bias.method
+    np.testing.assert_array_equal(legacy.bias._shift_array, canonical.bias._shift_array)
+
+
+def test_canonical_lag_names_are_available_from_public_apis():
+    """Canonical class and helper are exposed by both flat APIs."""
+    import mne_denoise.dss as dss_api
+    import mne_denoise.dss.variants as variants_api
+
+    assert dss_api.LagAveragingBias is LagAveragingBias
+    assert dss_api.lag_averaging_dss is lag_averaging_dss
+    assert variants_api.lag_averaging_dss is lag_averaging_dss


### PR DESCRIPTION
## Summary

This stacked draft makes the existing temporal DSS behavior mechanically explicit before true time-shift DSS is added.

- Rename the existing bias-side operator to `LagAveragingBias` and its convenience constructor to `lag_averaging_dss`.
- Retain `TimeShiftBias` and `time_shift_dss` as 0.x compatibility names that emit `FutureWarning` and are scheduled for removal in 1.0.
- Reserve `TimeShiftDSS` for a future data-side lag-augmented spatiotemporal estimator; this PR does not implement or export it.
- Give `CycleAverageBias` explicit `window_unit={"samples","seconds"}` and `event_origin={"data","raw"}` contracts.
- Convert second-valued windows with documented nearest-sample rounding and subtract MNE `Raw.first_samp` exactly once at construction.
- Preserve the legacy implicit unit/data-origin behavior behind 0.x `FutureWarning` compatibility paths.
- Process lag averaging independently per epoch and make CycleAverageBias's 3D concatenation explicitly epoch-major.
- Update the public exports, API reference, guide, gallery examples, and compatibility/invariant tests.

## Why

The released `TimeShiftBias` averages shifted copies on the bias side and still learns an ordinary spatial DSS filter. Calling that true time-shift DSS conflates it with the lag-augmented method described in the literature. Separately, `CycleAverageBias` previously inferred window units from the presence of `sfreq` and treated MNE acquisition sample numbers as array-relative positions, which could silently shift every event when `Raw.first_samp != 0`.

## Stacking

This PR targets `codex/dss-operation-semantics` (draft PR #56). Review the single commit above base SHA `3bc9696fed2f8ee6f8227f87a2013a2dedbf1163`. It must remain stacked until #56 lands.

## Validation

- Python 3.12 / MNE 1.12: **1,064 passed, 20 expected parity skips** (full repository)
- Python 3.10 / MNE 1.9 after the exact base rebase: **1,065 passed, 20 expected parity skips** (full repository)
- Focused temporal/artifact/variant suite: **58 passed** on both Python 3.10 and 3.12
- Ruff and all repository pre-commit hooks: passed
- Sphinx executed the renamed temporal gallery and generated both new API pages. The full `-W` build reached completion with 32/34 examples; only two unrelated ZapLine examples failed because their external data host returned HTTP 503.

This remains a draft. No evidence tier or scientific validation claim is added by these API and correctness contracts.

### Post-review hardening

- uses exact signed-64-bit conversion for event and window samples
- rejects uint64/Python-integer/window overflow instead of wrapping
- subtracts `first_samp` with checked Python integer arithmetic
- uses subtraction-based event bounds checks so int64 extremes cannot appear valid
- adds range-boundary regressions on Python 3.10 and 3.12