### PR TITLE
Fix DSS MNE input and operation contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,20 @@ from mne_denoise.dss import DSS, AverageBias
 epochs = mne.read_epochs("sample-epo.fif")
 
 # Create DSS with trial-average bias
-dss = DSS(bias=AverageBias(), n_components=5)
+dss = DSS(bias=AverageBias(), n_components=5, component_action="extract")
 dss.fit(epochs)
 
 # Option 1: Extract source time courses
 sources = dss.transform(epochs)
 
-# Option 2: Reconstruct denoised sensor data
-cleaned_epochs = dss.transform(epochs, return_type="epochs")
+# Option 2: Retain the leading two reproducible components in sensor space
+enhancer = DSS(
+    bias=AverageBias(),
+    n_components=5,
+    n_select=2,
+    component_action="retain",
+)
+enhanced_epochs = enhancer.fit_transform(epochs)
 ```
 
 ### DSS: Extracting Oscillations

--- a/docs/changes/devel/69.bugfix.rst
+++ b/docs/changes/devel/69.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed DSS fitting and reconstruction for MNE objects with bad channels, and
+preserved Raw annotations, acquisition sample coordinates, projections, and
+sample rejection consistently between baseline and biased covariance estimates.

--- a/docs/changes/devel/69.feature.rst
+++ b/docs/changes/devel/69.feature.rst
@@ -1,0 +1,3 @@
+Replaced the ambiguous DSS ``return_type`` behavior with explicit
+``component_action`` operations for extracting, retaining, or subtracting
+selected components while preserving segmented adaptive subtraction.

--- a/docs/changes/devel/69.removal.rst
+++ b/docs/changes/devel/69.removal.rst
@@ -1,0 +1,2 @@
+Removed the ambiguous DSS ``return_type`` parameter in favor of the single
+``component_action`` operation contract.

--- a/docs/dss.md
+++ b/docs/dss.md
@@ -15,7 +15,7 @@ from mne_denoise.zapline import ZapLine
 data = np.random.randn(64, 10000)  # 64 channels, 10000 samples
 bias = BandpassBias(freq_band=(8, 12), sfreq=500)
 
-dss = DSS(bias=bias, n_components=5)
+dss = DSS(bias=bias, n_components=5, component_action="extract")
 dss.fit(data)
 alpha_sources = dss.transform(data)
 
@@ -46,6 +46,43 @@ dss.fit(data)
 sources = dss.transform(data)
 reconstructed = dss.inverse_transform(sources[:3])  # Keep top 3
 ```
+
+### Component operations
+
+Use `component_action` to state whether DSS components should be extracted,
+retained, or removed. It is the single operation contract for both
+`transform()` and `fit_transform()`.
+
+```python
+# Return four DSS component time courses.
+sources = DSS(
+    bias=my_bias_function,
+    n_components=4,
+    component_action="extract",
+).fit_transform(data)
+
+# Reconstruct the leading two components in sensor space.
+target = DSS(
+    bias=my_bias_function,
+    n_components=4,
+    n_select=2,
+    component_action="retain",
+).fit_transform(data)
+
+# Remove the leading two components from the input.
+cleaned = DSS(
+    bias=my_bias_function,
+    n_components=4,
+    n_select=2,
+    component_action="subtract",
+).fit_transform(data)
+```
+
+For `retain`, leaving `n_select=None` retains every fitted component. For
+`subtract`, leaving it unset is an exact no-op. Adaptive `fit_transform()`
+supports subtraction only because every segment has a separately fitted
+component basis; global extraction or retention remains available through
+`fit().transform()`.
 
 ### Iterative (Nonlinear) DSS
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -68,11 +68,15 @@ You can use the ``DSS`` class directly with MNE objects.
    epochs = mne.read_epochs("sample_epochs.fif")
 
    # Apply DSS to enhance evoked response
-   dss = DSS(bias=TrialAverageBias(), n_components=5)
-   dss.fit(epochs)
+   dss = DSS(
+       bias=TrialAverageBias(),
+       n_components=5,
+       n_select=2,
+       component_action="subtract",
+   )
 
-   # Return denoised epochs (projected back to sensor space)
-   epochs_clean = dss.transform(epochs, return_type="epochs")
+   # Remove the leading two biased components in sensor space.
+   epochs_clean = dss.fit_transform(epochs)
 
 Example gallery
 ---------------

--- a/examples/dss/plot_01_dss_fundamentals.py
+++ b/examples/dss/plot_01_dss_fundamentals.py
@@ -139,7 +139,7 @@ print(f"Created epochs: {epochs.get_data().shape}")
 # Bias: Maximize power of the mean over epochs.
 
 print("\n--- Synthetic: Trial Average Bias ---")
-dss_evoked = DSS(n_components=3, bias=AverageBias(), return_type="sources")
+dss_evoked = DSS(n_components=3, bias=AverageBias(), component_action="extract")
 dss_evoked.fit(epochs)
 
 # Visualize

--- a/examples/dss/plot_02_artifact_correction.py
+++ b/examples/dss/plot_02_artifact_correction.py
@@ -82,7 +82,11 @@ eog_sensor_picks = np.arange(len(eog_epochs.ch_names))
 # We use AverageBias(axis='epochs') which works on pre-epoched data.
 # Note: We'll compare with CycleAverageBias later (artifact-specific approach).
 
-dss_eog = DSS(n_components=10, bias=AverageBias(axis="epochs"), return_type="sources")
+dss_eog = DSS(
+    n_components=10,
+    bias=AverageBias(axis="epochs"),
+    component_action="extract",
+)
 dss_eog.fit(eog_epochs)
 
 # %%
@@ -209,7 +213,11 @@ window_samples = (-int(0.1 * raw.info["sfreq"]), int(0.1 * raw.info["sfreq"]))
 bias_cycle = CycleAverageBias(event_samples=blink_samples, window=window_samples)
 
 # Fit DSS on continuous MEG data
-dss_cycle = DSS(n_components=10, bias=bias_cycle, return_type="sources")
+dss_cycle = DSS(
+    n_components=10,
+    bias=bias_cycle,
+    component_action="extract",
+)
 dss_cycle.fit(raw_meg)
 
 print("Fitted DSS with CycleAverageBias")

--- a/examples/tutorials/viz_showcase.ipynb
+++ b/examples/tutorials/viz_showcase.ipynb
@@ -307,7 +307,7 @@
    "source": [
     "\"\"\"Cell 4.2 · Fit DSS on training epochs, reconstruct denoised data.\"\"\"\n",
     "bias = AverageBias(axis=\"epochs\")\n",
-    "dss = DSS(bias=bias, n_components=DSS_N_COMPONENTS, return_type=\"sources\")\n",
+    "dss = DSS(bias=bias, n_components=DSS_N_COMPONENTS, component_action=\"extract\")\n",
     "dss.fit(epochs_train)\n",
     "\n",
     "# Transform → zero out components beyond N_KEEP → inverse transform\n",
@@ -1873,7 +1873,7 @@
    "source": [
     "# ── Fit DSS ──\n",
     "bias = AverageBias(axis=\"epochs\")\n",
-    "dss = DSS(bias=bias, n_components=DSS_N_COMPONENTS, return_type=\"sources\")\n",
+    "dss = DSS(bias=bias, n_components=DSS_N_COMPONENTS, component_action=\"extract\")\n",
     "dss.fit(epochs_train)\n",
     "\n",
     "sources_train = dss.transform(epochs_train)\n",

--- a/mne_denoise/dss/linear.py
+++ b/mne_denoise/dss/linear.py
@@ -52,6 +52,8 @@ from .utils.whitening import (
 
 logger = logging.getLogger(__name__)
 
+_COMPONENT_ACTIONS = frozenset({"extract", "retain", "subtract"})
+
 # -----------------------------------------------------------------------------
 # 1. Core Algorithm
 # -----------------------------------------------------------------------------
@@ -325,7 +327,9 @@ class DSS(BaseEstimator, TransformerMixin):
         independently per segment.  This handles **non-stationary**
         artifacts whose spatial or spectral profile changes over
         time.  The per-segment pathway runs in :meth:`fit_transform`;
-        :meth:`fit` still produces a single global fit.
+        :meth:`fit` still produces a single global fit. Segmented
+        :meth:`fit_transform` requires ``component_action='subtract'``
+        because component bases differ between segments.
 
         This is the same switch :class:`~mne_denoise.zapline.ZapLine`
         exposes as ``adaptive``, which inherits this parameter directly.
@@ -356,9 +360,14 @@ class DSS(BaseEstimator, TransformerMixin):
         strength.  Only effective when ``adaptive=True``.  Mirrors
         ZapLine-plus's fixed-removal floor (``fixedNremove``; Klug &
         Kloosterman, 2022).
-    return_type : {'sources', 'epochs', 'raw'}
-        Type of object to return from `transform`. 'sources' returns a numpy array
-        of DSS components. 'epochs'/'raw' returns the denoised input object.
+    component_action : {'extract', 'retain', 'subtract'}, default='extract'
+        Explicit operation applied to DSS components. ``'extract'`` returns
+        component time courses. ``'retain'`` reconstructs the leading selected
+        components in sensor space. ``'subtract'`` removes them from the input.
+        ``n_select`` controls the number retained or subtracted; when it is
+        ``None``, retention uses every fitted component and subtraction is an
+        exact no-op. In adaptive :meth:`fit_transform`, only subtraction is
+        supported because each segment has a different fitted basis.
     whiten : bool, default=False
         If True, decompose all data channel types jointly (e.g. mag + grad + eeg)
         instead of isolating a single homogeneous type. The data is whitened
@@ -396,14 +405,19 @@ class DSS(BaseEstimator, TransformerMixin):
     >>> # Create a bias (e.g. emphasize 10Hz oscillations)
     >>> bias = BandpassBias(sfreq=250, freq=10, bandwidth=2)
     >>> # Initialize DSS
-    >>> dss = DSS(bias=bias, n_components=3)
+    >>> dss = DSS(bias=bias, n_components=3, component_action="extract")
     >>> # Fit on data (MNE Raw/Epochs or NumPy)
     >>> dss.fit(raw_data)
     >>> # Extract sources
     >>> sources = dss.transform(raw_data)
-    >>> # Or return denoised data
-    >>> dss.return_type = "raw"
-    >>> denoised_raw = dss.transform(raw_data)
+    >>> # Or remove the leading biased component in sensor space
+    >>> cleaner = DSS(
+    ...     bias=bias,
+    ...     n_components=3,
+    ...     n_select=1,
+    ...     component_action="subtract",
+    ... )
+    >>> denoised_raw = cleaner.fit_transform(raw_data)
 
     See Also
     --------
@@ -429,7 +443,7 @@ class DSS(BaseEstimator, TransformerMixin):
         crossfade: float = 0.0,
         max_prop_remove: float | None = None,
         min_select: int = 0,
-        return_type: str = "sources",
+        component_action: str = "extract",
         whiten: bool = False,
         noise_cov=None,
         verbose: bool | str | int | None = None,
@@ -451,7 +465,7 @@ class DSS(BaseEstimator, TransformerMixin):
         self.crossfade = crossfade
         self.max_prop_remove = max_prop_remove
         self.min_select = min_select
-        self.return_type = return_type
+        self.component_action = component_action
         self.whiten = whiten
         self.noise_cov = noise_cov
         self.verbose = verbose
@@ -470,6 +484,7 @@ class DSS(BaseEstimator, TransformerMixin):
         self._dewhitener_: np.ndarray | None = None
         self._smoother = None  # Resolved SmoothingBias instance
         self._mne_info = None
+        self._mne_ch_names_: list[str] | None = None
 
     def fit(
         self,
@@ -500,6 +515,8 @@ class DSS(BaseEstimator, TransformerMixin):
             The fitted transformer.
         """
         set_log_level_from_verbose(self.verbose)
+        self._mne_ch_names_ = None
+        self._validate_component_action()
         if self.adaptive:
             logger.info(
                 "DSS(adaptive=True).fit() computes a single global fit. "
@@ -523,9 +540,19 @@ class DSS(BaseEstimator, TransformerMixin):
 
         # If smoothing is enabled, decompose and fit on the residual only
         if self._smoother is not None:
-            data, _, _, _, _, _ = extract_data_from_mne(
-                X_norm, channel_first_epochs=True
+            data, _, _, orig_inst, picks, ch_names = extract_data_from_mne(
+                X_norm,
+                ch_names=self._mne_ch_names_,
+                exclude_bads=self._mne_ch_names_ is None,
+                channel_first_epochs=True,
             )
+            self._mne_ch_names_ = ch_names
+            if orig_inst is not None:
+                fitted_inst = orig_inst.copy()
+                if picks is not None:
+                    fitted_inst.pick(picks)
+                self.info_ = fitted_inst.info
+                self._mne_info = self.info_
             data_residual = data - self._smoother.apply(data)
             # Fit DSS on residual (always numpy path)
             self._fit_numpy(data_residual, weights=weights)
@@ -571,6 +598,15 @@ class DSS(BaseEstimator, TransformerMixin):
                 "knee_rel_floor, and knee_min_ratio."
             )
         return self.n_select
+
+    def _validate_component_action(self) -> None:
+        """Validate the explicit component-operation contract."""
+        if self.component_action not in _COMPONENT_ACTIONS:
+            allowed = ", ".join(sorted(_COMPONENT_ACTIONS))
+            raise ValueError(
+                "component_action must be one of "
+                f"{{{allowed}}}, got {self.component_action!r}."
+            )
 
     def auto_select(self, threshold: float | None = None) -> int:
         """Automatically determine how many DSS components are significant.
@@ -645,22 +681,16 @@ class DSS(BaseEstimator, TransformerMixin):
         This mimics MNE's Scaling capabilities, ensuring channels with different
         units (e.g. MAG vs GRAD) contribute equally.
         """
-        # Helper to get numpy data
-        is_mne = False
-        mne_type = None
-        if mne is not None and isinstance(X, BaseRaw | BaseEpochs | Evoked):
-            data = X.get_data()
-            is_mne = True
-            if isinstance(X, BaseEpochs):
-                mne_type = "epochs"
-                # MNE Epochs: (n_epochs, n_channels, n_times) -> (n_channels, n_times, n_epochs)
-                data = np.transpose(data, (1, 2, 0))
-            elif isinstance(X, Evoked):
-                mne_type = "evoked"
-            else:
-                mne_type = "raw"
-        else:
-            data = X
+        is_mne = mne is not None and isinstance(X, BaseRaw | BaseEpochs | Evoked)
+        fitted_ch_names = None if fit else self._mne_ch_names_
+        data, _, mne_type, orig_inst, picks, ch_names = extract_data_from_mne(
+            X,
+            ch_names=fitted_ch_names,
+            exclude_bads=fit,
+            channel_first_epochs=True,
+        )
+        if fit and is_mne:
+            self._mne_ch_names_ = ch_names
 
         # Now data is always (n_channels, ...) for both 2D and 3D
         orig_shape = data.shape
@@ -686,40 +716,18 @@ class DSS(BaseEstimator, TransformerMixin):
         if len(orig_shape) == 3:
             data_norm = data_norm.reshape(orig_shape)
 
-        if is_mne:
-            if mne_type == "raw":
-                out = mne.io.RawArray(data_norm, X.info.copy(), verbose=False)
-                # Preserve annotations
-                if hasattr(X, "annotations") and X.annotations is not None:
-                    out.set_annotations(X.annotations)
-                return out
-            elif mne_type == "epochs":
-                # Transpose back to MNE format: (n_ch, n_times, n_epochs) -> (n_epochs, n_ch, n_times)
-                data_norm = np.transpose(data_norm, (2, 0, 1))
-                out = mne.EpochsArray(
-                    data_norm,
-                    X.info.copy(),
-                    events=getattr(X, "events", None),
-                    tmin=getattr(X, "tmin", 0),
-                    event_id=getattr(X, "event_id", None),
-                    verbose=False,
-                )
-                # Preserve metadata
-                if hasattr(X, "metadata") and X.metadata is not None:
-                    out.metadata = X.metadata.copy()
-                return out
-            else:  # Evoked
-                out = mne.EvokedArray(
-                    data_norm,
-                    X.info.copy(),
-                    tmin=getattr(X, "tmin", 0),
-                    comment=getattr(X, "comment", ""),
-                    nave=getattr(X, "nave", 1),
-                    verbose=False,
-                )
-                return out
-        else:
+        if not is_mne:
             return data_norm
+
+        if mne_type == "epochs":
+            data_norm = np.transpose(data_norm, (2, 0, 1))
+        return reconstruct_mne_object(
+            data_norm,
+            orig_inst,
+            mne_type,
+            picks=picks,
+            verbose=False,
+        )
 
     def _apply_bias(self, data: np.ndarray) -> np.ndarray:
         """Apply bias function to data."""
@@ -734,43 +742,51 @@ class DSS(BaseEstimator, TransformerMixin):
         weights: np.ndarray | None = None,
     ) -> None:
         """Fit using MNE objects."""
-        self.info_ = inst.info
-
-        if weights is not None:
-            # If weights provided, extract data and use numpy path
-            data = inst.get_data()
-            self._fit_numpy(data, weights=weights)
-            return
-
         method = self.cov_method
         kws = self.cov_kws.copy() if self.cov_kws else {}
         # Set defaults if not in kws
         kws.setdefault("rank", self.rank)
         kws.setdefault("verbose", False)
 
-        data, _, _, _, picks, ch_names = extract_data_from_mne(
-            inst, channel_first_epochs=True
+        data, _, mne_type, _, picks, ch_names = extract_data_from_mne(
+            inst,
+            ch_names=self._mne_ch_names_,
+            exclude_bads=self._mne_ch_names_ is None,
+            channel_first_epochs=True,
         )
         self._mne_ch_names_ = ch_names
 
-        # MNE covariance computation requires the inst object to match the array
+        # MNE covariance computation and the fitted spatial matrices must use
+        # exactly the same good-channel contract.
         if picks is not None:
             inst = inst.copy().pick(picks)
+        self.info_ = inst.info
+        self._mne_info = self.info_
+
+        if weights is not None:
+            # Weighted MNE input uses the canonical channel-first NumPy path.
+            self._fit_numpy(data, weights=weights)
+            return
 
         biased_data = self._apply_bias(data)
 
         if isinstance(inst, BaseEpochs):
             biased_data = np.transpose(biased_data, (2, 0, 1))
 
+        biased_inst = reconstruct_mne_object(
+            biased_data,
+            inst,
+            mne_type,
+            verbose=False,
+        )
+
         if isinstance(inst, BaseRaw):
             kws.setdefault("tstep", 2.0)
             baseline_cov = mne.compute_raw_covariance(inst, method=method, **kws)
-            biased_inst = mne.io.RawArray(biased_data, inst.info, verbose=False)
             biased_cov = mne.compute_raw_covariance(biased_inst, method=method, **kws)
 
         elif isinstance(inst, BaseEpochs):
             baseline_cov = mne.compute_covariance(inst, method=method, **kws)
-            biased_inst = mne.EpochsArray(biased_data, inst.info, verbose=False)
             biased_cov = mne.compute_covariance(biased_inst, method=method, **kws)
 
         else:  # Evoked - use numpy path since MNE doesn't support Evoked covariance
@@ -835,13 +851,20 @@ class DSS(BaseEstimator, TransformerMixin):
         for key in ("rank", "verbose", "tstep"):
             kws.pop(key, None)
 
-        data, _, _, orig_inst, _, ch_names = extract_data_from_mne(
+        data, _, _, orig_inst, picks, ch_names = extract_data_from_mne(
             X,
             auto_pick="data",
+            exclude_bads=True,
             channel_first_epochs=True,
         )
         self._mne_ch_names_ = ch_names
-        self.info_ = orig_inst.info if orig_inst is not None else None
+        if orig_inst is not None:
+            fitted_inst = orig_inst.copy()
+            if picks is not None:
+                fitted_inst.pick(picks)
+            self.info_ = fitted_inst.info
+        else:
+            self.info_ = None
         self._mne_info = self.info_
 
         data_w = self._prewhiten_sensor_data(
@@ -894,7 +917,7 @@ class DSS(BaseEstimator, TransformerMixin):
     def transform(
         self, X: BaseRaw | BaseEpochs | Evoked | np.ndarray
     ) -> np.ndarray | BaseRaw | BaseEpochs | Evoked:
-        """Apply DSS spatial filters.
+        """Apply the configured DSS component operation.
 
         Parameters
         ----------
@@ -905,11 +928,29 @@ class DSS(BaseEstimator, TransformerMixin):
         Returns
         -------
         out : array | Raw | Epochs | Evoked
-            If return_type='sources', returns the source time series.
-            If return_type='raw'/'epochs'/'evoked', returns the reconstructed data (denoised)
-            projected back to sensor space (keeping n_components).
+            Component time courses for extraction, otherwise transformed data
+            in the same container type as the input.
         """
+        self._validate_component_action()
+        return self._transform_with_action(X, self.component_action)
+
+    def _operation_component_count(self, action: str, n_available: int) -> int:
+        """Return the leading component count used in sensor space."""
+        if action == "retain" and self.n_selected_ is None:
+            return n_available
+        if self.n_selected_ is None:
+            return 0
+        return min(max(int(self.n_selected_), 0), n_available)
+
+    def _transform_with_action(
+        self,
+        X: BaseRaw | BaseEpochs | Evoked | np.ndarray,
+        action: str,
+    ) -> np.ndarray | BaseRaw | BaseEpochs | Evoked:
+        """Apply a validated operation without mutating estimator parameters."""
         set_log_level_from_verbose(self.verbose)
+        if action not in _COMPONENT_ACTIONS:
+            raise ValueError(f"Unknown component action {action!r}.")
         if self.filters_ is None:
             raise RuntimeError("DSS not fitted. Call fit() first.")
 
@@ -921,7 +962,7 @@ class DSS(BaseEstimator, TransformerMixin):
 
         # Helper to extract data
         # DSS internal convention for Epochs: (n_channels, n_times, n_epochs)
-        data, _, mne_type, orig_inst, picks, _ = extract_data_from_mne(
+        data, _, mne_type, _, picks, _ = extract_data_from_mne(
             X_in,
             ch_names=getattr(self, "_mne_ch_names_", None),
             channel_first_epochs=True,
@@ -939,9 +980,11 @@ class DSS(BaseEstimator, TransformerMixin):
         if data_for_dss.ndim == 3:
             n_ch, n_times, n_epochs = data_for_dss.shape
             data_2d = data_for_dss.reshape(n_ch, -1)
+            full_data_2d = data.reshape(n_ch, -1)
         else:
             n_ch, n_times = data_for_dss.shape
             data_2d = data_for_dss
+            full_data_2d = data
 
         # Center using mean on data_2d
         # DSS implies zero-mean assumption for correct projection
@@ -950,30 +993,32 @@ class DSS(BaseEstimator, TransformerMixin):
 
         sources = self.filters_ @ data_centered
 
-        if self.return_type == "sources":
+        if action == "extract":
             if len(orig_shape) == 3:
-                sources = sources.reshape(
-                    self.n_components or sources.shape[0], n_times, n_epochs
-                )
+                sources = sources.reshape(sources.shape[0], n_times, n_epochs)
                 if mne_type == "epochs":
                     # Return as (n_epochs, n_components, n_times)
                     return sources.transpose(2, 0, 1)
             return sources
 
-        # Use only kept components
-        n_keep = self.n_components if self.n_components else self.filters_.shape[0]
-        # mixing shape: (n_channels, n_components)
-        rec = self.mixing_[:, :n_keep] @ sources[:n_keep]
-        rec += mean_
+        n_action = self._operation_component_count(action, sources.shape[0])
+        if action == "subtract" and n_action == 0:
+            if hasattr(X, "copy"):
+                return X.copy()
+            return np.array(X, copy=True)
 
-        # Add back smooth component if it was separated
-        if data_smooth is not None:
-            smooth_2d = (
-                data_smooth.reshape(data_smooth.shape[0], -1)
-                if data_smooth.ndim == 3
-                else data_smooth
-            )
-            rec = rec + smooth_2d
+        selected = self.mixing_[:, :n_action] @ sources[:n_action]
+        if action == "subtract":
+            rec = full_data_2d - selected
+        else:
+            rec = selected + mean_
+            if data_smooth is not None:
+                smooth_2d = (
+                    data_smooth.reshape(data_smooth.shape[0], -1)
+                    if data_smooth.ndim == 3
+                    else data_smooth
+                )
+                rec = rec + smooth_2d
 
         # Reshape to original
         if len(orig_shape) == 3:
@@ -991,7 +1036,11 @@ class DSS(BaseEstimator, TransformerMixin):
             rec = np.transpose(rec, (2, 0, 1))
 
         return reconstruct_mne_object(
-            rec, orig_inst, mne_type, picks=picks, verbose=False
+            rec,
+            X if mne_type != "array" else None,
+            mne_type,
+            picks=picks,
+            verbose=False,
         )
 
     def inverse_transform(
@@ -1095,7 +1144,7 @@ class DSS(BaseEstimator, TransformerMixin):
     # -----------------------------------------------------------------
 
     def fit_transform(self, X, y=None, **fit_params):
-        """Fit and transform data in one step.
+        """Fit and apply the configured component operation.
 
         In **adaptive mode** (``adaptive=True``), the data is split into
         segments and each segment gets its own independent DSS fit +
@@ -1103,8 +1152,9 @@ class DSS(BaseEstimator, TransformerMixin):
         processing because ``fit()`` alone is not meaningful when
         filters differ per segment.
 
-        In standard mode, this is equivalent to
-        ``self.fit(X).transform(X)``.
+        With an explicit ``component_action``, standard mode is equivalent to
+        ``self.fit(X).transform(X)``. Adaptive mode remains a deliberately
+        transductive, per-segment fit-and-subtract operation.
 
         Parameters
         ----------
@@ -1119,41 +1169,26 @@ class DSS(BaseEstimator, TransformerMixin):
         -------
         X_out : ndarray | Raw | Epochs | Evoked
             In adaptive mode, returns cleaned data (same type as input).
-            In standard mode with ``return_type='sources'``, returns DSS
-            source time-series.  With any other ``return_type``, returns
-            cleaned (denoised) data produced by subtracting the artifact
-            captured by the first ``n_selected_`` components.
+            In standard mode, the result follows ``component_action``.
         """
+        self._validate_component_action()
         if not self.adaptive:
             self.fit(X, **fit_params)
+            return self.transform(X)
 
-            if self.return_type == "sources":
-                return self.transform(X)
-
-            # ── Denoise via artifact subtraction ──
-            data, _, mne_type, orig_inst, _, _ = extract_data_from_mne(X)
-
-            n_remove = self.n_selected_ if self.n_selected_ is not None else 0
-            if n_remove > 0:
-                # Temporarily switch to get source time-series
-                saved_rt = self.return_type
-                self.return_type = "sources"
-                try:
-                    sources = self.transform(X)
-                finally:
-                    self.return_type = saved_rt
-
-                artifact = self.inverse_transform(
-                    sources, component_indices=np.arange(n_remove)
-                )
-                cleaned = data - artifact
-            else:
-                cleaned = data
-
-            return reconstruct_mne_object(cleaned, orig_inst, mne_type, verbose=False)
+        if self.component_action != "subtract":
+            raise ValueError(
+                "adaptive fit_transform supports only "
+                "component_action='subtract' because each segment has a "
+                "different fitted component basis. Use fit().transform() for "
+                "global extraction or retention."
+            )
 
         # --- adaptive (per-segment) mode ---
-        data, extracted_sfreq, mne_type, orig_inst, _, _ = extract_data_from_mne(X)
+        data, extracted_sfreq, mne_type, orig_inst, picks, ch_names = (
+            extract_data_from_mne(X, exclude_bads=True)
+        )
+        self._mne_ch_names_ = ch_names
 
         # Determine sfreq
         sfreq = extracted_sfreq
@@ -1197,7 +1232,13 @@ class DSS(BaseEstimator, TransformerMixin):
         if is_epochs:
             cleaned = continuous_to_epochs(cleaned, (n_ep, n_ch, n_t))
 
-        return reconstruct_mne_object(cleaned, orig_inst, mne_type, verbose=False)
+        return reconstruct_mne_object(
+            cleaned,
+            orig_inst,
+            mne_type,
+            picks=picks,
+            verbose=False,
+        )
 
     def _resolve_segmenter(self, sfreq: float):
         """Resolve the segmenter parameter.
@@ -1364,7 +1405,6 @@ class DSS(BaseEstimator, TransformerMixin):
             n_select=self._effective_n_select(),
             segmenter=None,
             crossfade=0.0,
-            return_type="sources",
             # Per-segment caps are applied by the caller, not the clone.
             max_prop_remove=None,
             min_select=0,

--- a/mne_denoise/dss/variants/ssvep.py
+++ b/mne_denoise/dss/variants/ssvep.py
@@ -51,8 +51,14 @@ def ssvep_dss(
     >>> dss.fit(epochs)
     >>> ssvep_sources = dss.transform(epochs)
 
-    >>> # Get denoised data back in sensor space
-    >>> dss = ssvep_dss(sfreq=250, stim_freq=12, return_type="epochs")
+    >>> # Retain the leading SSVEP component in sensor space
+    >>> dss = ssvep_dss(
+    ...     sfreq=250,
+    ...     stim_freq=12,
+    ...     n_components=3,
+    ...     n_select=1,
+    ...     component_action="retain",
+    ... )
     >>> dss.fit(epochs)
     >>> denoised_epochs = dss.transform(epochs)
     """

--- a/mne_denoise/utils.py
+++ b/mne_denoise/utils.py
@@ -121,6 +121,7 @@ def extract_data_from_mne(
     auto_pick: bool | str = True,
     concatenate_epochs: bool = False,
     channel_first_epochs: bool = False,
+    exclude_bads: bool = False,
 ) -> tuple[np.ndarray, float | None, str, Any, np.ndarray | None, list[str] | None]:
     """
     Extract data and metadata from an MNE object or NumPy-compatible array.
@@ -148,6 +149,10 @@ def extract_data_from_mne(
         If True, return MNE Epochs as
         ``(n_channels, n_times, n_epochs)``. Cannot be combined with
         ``concatenate_epochs=True``.
+    exclude_bads : bool, default=False
+        If True, omit channels listed in ``X.info['bads']`` from automatic
+        channel selection. This has no effect when ``ch_names`` explicitly
+        defines the fitted channel contract.
 
     Returns
     -------
@@ -224,6 +229,22 @@ def extract_data_from_mne(
                 picks = _get_homogeneous_picks(X, auto_pick=auto_pick)
             else:
                 picks = None
+
+            if exclude_bads:
+                candidate_picks = (
+                    np.arange(len(X.ch_names), dtype=int)
+                    if picks is None
+                    else np.asarray(picks, dtype=int)
+                )
+                bads = set(X.info["bads"])
+                picks = np.asarray(
+                    [pick for pick in candidate_picks if X.ch_names[pick] not in bads],
+                    dtype=int,
+                )
+                if picks.size == 0:
+                    raise ValueError(
+                        "No good data channels remain after excluding bads"
+                    )
 
             if picks is not None:
                 data = X.get_data(picks=picks)

--- a/mne_denoise/viz/_utils.py
+++ b/mne_denoise/viz/_utils.py
@@ -109,14 +109,13 @@ def _get_components(estimator, data=None):
         )
 
     # 2. Compute sources for the provided data
-    # Check if we need to force 'return_type' for LinearDSS
-    if hasattr(estimator, "return_type"):
-        old_return_type = estimator.return_type
+    if hasattr(estimator, "component_action"):
+        old_action = estimator.component_action
         try:
-            estimator.return_type = "sources"
+            estimator.component_action = "extract"
             sources = estimator.transform(data)
         finally:
-            estimator.return_type = old_return_type
+            estimator.component_action = old_action
     else:
         # Assumed to be IterativeDSS or similar which transforms to sources
         sources = estimator.transform(data)

--- a/mne_denoise/zapline/core.py
+++ b/mne_denoise/zapline/core.py
@@ -281,6 +281,7 @@ class ZapLine(DSS):
             crossfade=crossfade,
             max_prop_remove=max_prop_remove,
             min_select=min_select,
+            component_action="subtract",
             n_select=n_select,
             selection_threshold=threshold,
             knee_rel_floor=knee_rel_floor,

--- a/scripts/run_erp_dss_benchmark.py
+++ b/scripts/run_erp_dss_benchmark.py
@@ -552,7 +552,7 @@ def apply_c2_dss(
 ):
     """C2: DSS (AverageBias)."""
     bias = AverageBias(axis="epochs")
-    dss = DSS(bias=bias, n_components=n_components, return_type="sources")
+    dss = DSS(bias=bias, n_components=n_components, component_action="extract")
     dss.fit(epochs_train)
 
     sources_test = dss.transform(epochs_test)
@@ -841,7 +841,11 @@ def run_group(subjects, deriv_root=None):
     #  QA Level A: Component Diagnostics
     # ══════════════════════════════════════════════════════════════════════
     bias_show = AverageBias(axis="epochs")
-    dss_show = DSS(bias=bias_show, n_components=DSS_N_COMPONENTS, return_type="sources")
+    dss_show = DSS(
+        bias=bias_show,
+        n_components=DSS_N_COMPONENTS,
+        component_action="extract",
+    )
     dss_show.fit(epochs_train_show)
     evals = dss_show.eigenvalues_
     n_ev = len(evals)

--- a/scripts/visual_qa.py
+++ b/scripts/visual_qa.py
@@ -174,7 +174,7 @@ epochs_train = epochs[np.arange(0, n_ep, 2)]
 epochs_test = epochs[np.arange(1, n_ep, 2)]
 
 bias = AverageBias(axis="epochs")
-dss = DSS(bias=bias, n_components=DSS_N_COMPONENTS, return_type="sources")
+dss = DSS(bias=bias, n_components=DSS_N_COMPONENTS, component_action="extract")
 dss.fit(epochs_train)
 
 sources_train = dss.transform(epochs_train)

--- a/tests/test_dss_operation_contract.py
+++ b/tests/test_dss_operation_contract.py
@@ -1,0 +1,247 @@
+"""Tests for explicit DSS component-operation semantics."""
+
+from __future__ import annotations
+
+import mne
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+from sklearn.base import clone
+
+from mne_denoise.dss import DSS
+from mne_denoise.dss.utils.segmentation import FixedWindowSegmenter
+
+
+def _ranked_bias(data):
+    """Give channels distinct deterministic bias scores."""
+    shape = (data.shape[0],) + (1,) * (data.ndim - 1)
+    weights = np.linspace(2.0, 0.5, data.shape[0]).reshape(shape)
+    return data * weights
+
+
+def _array_data(seed=0, shape=(6, 600)):
+    """Create nonzero-mean, differently scaled channel data."""
+    rng = np.random.default_rng(seed)
+    data = rng.standard_normal(shape)
+    channel_shape = (shape[0],) + (1,) * (len(shape) - 1)
+    offsets = np.linspace(-3.0, 4.0, shape[0]).reshape(channel_shape)
+    scales = np.geomspace(0.2, 5.0, shape[0]).reshape(channel_shape)
+    return data * scales + offsets
+
+
+@pytest.mark.parametrize("action", ["extract", "retain", "subtract"])
+def test_explicit_standard_fit_transform_is_composition(action):
+    """Every explicit standard operation follows the sklearn composition."""
+    data = _array_data()
+    params = {
+        "bias": _ranked_bias,
+        "n_components": 4,
+        "n_select": 2,
+        "component_action": action,
+        "normalize_input": False,
+    }
+
+    expected = DSS(**params).fit(data).transform(data)
+    actual = DSS(**params).fit_transform(data)
+
+    assert_allclose(actual, expected, rtol=1e-12, atol=1e-12)
+
+
+def test_explicit_actions_have_distinct_algebra():
+    """Extraction, retention, and subtraction implement their named algebra."""
+    data = _array_data()
+    est = DSS(
+        bias=_ranked_bias,
+        n_components=4,
+        n_select=2,
+        component_action="extract",
+        normalize_input=False,
+    ).fit(data)
+
+    sources = est.transform(data)
+    selected = est.mixing_[:, :2] @ sources[:2]
+    mean = data.mean(axis=1, keepdims=True)
+
+    retained = est.set_params(component_action="retain").transform(data)
+    subtracted = est.set_params(component_action="subtract").transform(data)
+
+    assert sources.shape == (4, data.shape[1])
+    assert_allclose(retained, selected + mean, rtol=1e-12, atol=1e-12)
+    assert_allclose(subtracted, data - selected, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.parametrize("normalize_input", [False, True])
+def test_full_rank_retain_reconstructs_input(normalize_input):
+    """Retention without a selection uses every fitted component."""
+    data = _array_data()
+    retained = DSS(
+        bias=_ranked_bias,
+        component_action="retain",
+        normalize_input=normalize_input,
+    ).fit_transform(data)
+
+    assert_allclose(retained, data, rtol=1e-9, atol=1e-9)
+
+
+@pytest.mark.parametrize("shape", [(6, 600), (6, 150, 4)])
+def test_subtract_without_selection_is_exact_copy(shape):
+    """Explicit subtraction with no selection is a non-mutating no-op."""
+    data = _array_data(shape=shape)
+    original = data.copy()
+    out = DSS(
+        bias=_ranked_bias,
+        component_action="subtract",
+        normalize_input=False,
+    ).fit_transform(data)
+
+    assert out is not data
+    assert_array_equal(out, data)
+    assert_array_equal(data, original)
+
+
+@pytest.mark.parametrize("shape", [(6, 600), (6, 150, 4)])
+@pytest.mark.parametrize("action", ["retain", "subtract"])
+def test_sensor_actions_preserve_array_layout(shape, action):
+    """Sensor-space operations preserve 2-D and 3-D array orientation."""
+    data = _array_data(shape=shape)
+    out = DSS(
+        bias=_ranked_bias,
+        n_components=4,
+        n_select=2,
+        component_action=action,
+        normalize_input=False,
+    ).fit_transform(data)
+
+    assert out.shape == data.shape
+
+
+@pytest.mark.parametrize("action", [None, "replace", "sources", "raw"])
+def test_invalid_component_action_is_rejected(action):
+    """Unknown operations fail before fitting any spatial model."""
+    with pytest.raises(ValueError, match="component_action"):
+        DSS(bias=_ranked_bias, component_action=action).fit(_array_data())
+
+
+def test_component_action_is_cloneable():
+    """The operation remains a regular sklearn constructor parameter."""
+    est = DSS(
+        bias=_ranked_bias,
+        n_select=2,
+        component_action="subtract",
+        normalize_input=False,
+    )
+
+    cloned = clone(est)
+
+    assert cloned.component_action == "subtract"
+    assert cloned.n_select == 2
+
+
+@pytest.mark.parametrize("action", ["retain", "subtract"])
+def test_raw_sensor_actions_preserve_metadata_and_bad_channels(action):
+    """Explicit Raw operations preserve the corrected MNE input contract."""
+    data = _array_data(shape=(4, 800)) * 1e-6
+    info = mne.create_info(["EEG0", "EEG1", "EEG2", "EEG3"], 200.0, "eeg")
+    raw = mne.io.RawArray(data, info, first_samp=321, verbose=False)
+    raw.info["bads"] = ["EEG3"]
+    raw.set_annotations(mne.Annotations([0.5], [0.25], ["marker"]))
+
+    out = DSS(
+        bias=_ranked_bias,
+        n_components=3,
+        n_select=1,
+        component_action=action,
+        normalize_input=False,
+    ).fit_transform(raw)
+
+    assert isinstance(out, mne.io.BaseRaw)
+    assert out.first_samp == raw.first_samp
+    assert out.annotations == raw.annotations
+    assert out.info["bads"] == raw.info["bads"]
+    assert_array_equal(out.get_data(picks=["EEG3"]), raw.get_data(picks=["EEG3"]))
+
+
+def test_epochs_extract_and_subtract_layouts():
+    """Explicit operations honor MNE Epochs source and sensor orientations."""
+    data = np.transpose(_array_data(shape=(4, 100, 5)), (2, 0, 1))
+    info = mne.create_info(4, 100.0, "eeg")
+    epochs = mne.EpochsArray(data, info, verbose=False)
+
+    sources = DSS(
+        bias=_ranked_bias,
+        n_components=3,
+        component_action="extract",
+        normalize_input=False,
+    ).fit_transform(epochs)
+    cleaned = DSS(
+        bias=_ranked_bias,
+        n_components=3,
+        n_select=1,
+        component_action="subtract",
+        normalize_input=False,
+    ).fit_transform(epochs)
+
+    assert sources.shape == (5, 3, 100)
+    assert isinstance(cleaned, mne.BaseEpochs)
+    assert cleaned.get_data().shape == data.shape
+
+
+def test_subtract_with_smoothing_removes_only_selected_residual():
+    """Subtraction keeps the smooth signal and removes the selected residual."""
+    data = _array_data(shape=(6, 800))
+    est = DSS(
+        bias=_ranked_bias,
+        n_components=4,
+        n_select=1,
+        smooth=5,
+        component_action="extract",
+        normalize_input=False,
+    ).fit(data)
+    sources = est.transform(data)
+    selected = est.mixing_[:, :1] @ sources[:1]
+
+    cleaned = est.set_params(component_action="subtract").transform(data)
+
+    assert_allclose(cleaned, data - selected, rtol=1e-12, atol=1e-12)
+
+
+def test_adaptive_explicit_subtract_runs_segments():
+    """Canonical subtraction must not bypass adaptive segment processing."""
+    data = _array_data(shape=(4, 800))
+    info = mne.create_info(4, 100.0, "eeg")
+    raw = mne.io.RawArray(data, info, verbose=False)
+    est = DSS(
+        bias=_ranked_bias,
+        n_components=3,
+        n_select=1,
+        component_action="subtract",
+        normalize_input=False,
+        adaptive=True,
+        segmenter=FixedWindowSegmenter(sfreq=100.0, window_len=2.0),
+    )
+
+    out = est.fit_transform(raw)
+
+    assert isinstance(out, mne.io.BaseRaw)
+    assert est.segment_results_ is not None
+    assert len(est.segment_results_) == 4
+
+
+@pytest.mark.parametrize("action", ["extract", "retain"])
+def test_adaptive_rejects_incompatible_explicit_actions(action):
+    """Segment-specific bases cannot produce one coherent extract/retain output."""
+    data = _array_data(shape=(4, 800))
+    info = mne.create_info(4, 100.0, "eeg")
+    raw = mne.io.RawArray(data, info, verbose=False)
+    est = DSS(
+        bias=_ranked_bias,
+        n_components=3,
+        n_select=1,
+        component_action=action,
+        normalize_input=False,
+        adaptive=True,
+        segmenter=FixedWindowSegmenter(sfreq=100.0, window_len=2.0),
+    )
+
+    with pytest.raises(ValueError, match="supports only.*subtract"):
+        est.fit_transform(raw)

--- a/tests/test_linear_dss.py
+++ b/tests/test_linear_dss.py
@@ -271,12 +271,12 @@ def test_dss_without_normalization():
     assert sources.shape == (3, 200)
 
 
-def test_dss_return_type_raw():
-    """DSS transform with return_type='raw' should reconstruct data."""
+def test_dss_retain_reconstructs_sensor_data():
+    """DSS retention should reconstruct sensor-space data."""
     rng = np.random.default_rng(42)
     data = rng.standard_normal((5, 200))
 
-    dss = DSS(bias=lambda x: x, n_components=3, return_type="raw")
+    dss = DSS(bias=lambda x: x, n_components=3, component_action="retain")
     dss.fit(data)
     rec = dss.transform(data)
 
@@ -552,8 +552,8 @@ def test_dss_with_mne_evoked():
     assert sources.shape == (3, n_times)
 
 
-def test_dss_mne_return_type_epochs():
-    """DSS transform with return_type should return MNE object."""
+def test_dss_mne_retain_returns_epochs():
+    """DSS retention should preserve an MNE Epochs container."""
     rng = np.random.default_rng(42)
     n_channels, n_times, n_epochs = 4, 50, 10
     sfreq = 100.0
@@ -565,7 +565,7 @@ def test_dss_mne_return_type_epochs():
     )
     epochs = mne.EpochsArray(data, info, verbose=False)
 
-    dss = DSS(bias=lambda x: x, n_components=3, return_type="epochs")
+    dss = DSS(bias=lambda x: x, n_components=3, component_action="retain")
     dss.fit(epochs)
     result = dss.transform(epochs)
 
@@ -573,8 +573,8 @@ def test_dss_mne_return_type_epochs():
     assert isinstance(result, mne.epochs.BaseEpochs)
 
 
-def test_dss_mne_return_type_raw():
-    """DSS transform with return_type='raw' should return Raw object."""
+def test_dss_mne_retain_returns_raw():
+    """DSS retention should preserve an MNE Raw container."""
     rng = np.random.default_rng(42)
     n_channels, n_samples = 4, 2000
     sfreq = 500.0
@@ -586,7 +586,7 @@ def test_dss_mne_return_type_raw():
     )
     raw = mne.io.RawArray(data, info, verbose=False)
 
-    dss = DSS(bias=lambda x: x, n_components=3, return_type="raw")
+    dss = DSS(bias=lambda x: x, n_components=3, component_action="retain")
     dss.fit(raw)
     result = dss.transform(raw)
 
@@ -824,6 +824,247 @@ def test_dss_mne_evoked_extracts_known_signal():
     assert correlation > 0.85, f"Evoked signal correlation {correlation} too low"
 
 
+@pytest.mark.parametrize("normalize_input", [False, True])
+def test_dss_raw_covariances_use_identical_sample_support(monkeypatch, normalize_input):
+    """Baseline and biased Raw covariance must see identical sample support."""
+    rng = np.random.default_rng(42)
+    info = mne.create_info(["EEG0", "EEG1", "EEG2"], 100.0, "eeg")
+    raw = mne.io.RawArray(
+        rng.standard_normal((3, 1000)),
+        info,
+        first_samp=1000,
+        verbose=False,
+    )
+    raw.set_annotations(
+        mne.Annotations(
+            onset=[2.0],
+            duration=[2.0],
+            description=["BAD_test"],
+        )
+    )
+    raw.set_eeg_reference(projection=True, verbose=False)
+
+    original_compute = mne.compute_raw_covariance
+    calls = []
+
+    def _record_support(inst, *args, **kwargs):
+        cov = original_compute(inst, *args, **kwargs)
+        calls.append(
+            {
+                "first_samp": inst.first_samp,
+                "annotations": inst.annotations.copy(),
+                "nfree": cov.nfree,
+                "projectors": [
+                    (projector["desc"], projector["active"])
+                    for projector in inst.info["projs"]
+                ],
+            }
+        )
+        return cov
+
+    monkeypatch.setattr(mne, "compute_raw_covariance", _record_support)
+    DSS(
+        bias=lambda data: data,
+        normalize_input=normalize_input,
+    ).fit(raw)
+
+    assert len(calls) == 2
+    assert calls[0]["first_samp"] == calls[1]["first_samp"] == raw.first_samp
+    assert calls[0]["annotations"] == calls[1]["annotations"]
+    assert calls[0]["nfree"] == calls[1]["nfree"]
+    assert calls[0]["nfree"] < raw.n_times - 1
+    assert calls[0]["projectors"] == calls[1]["projectors"]
+
+
+@pytest.mark.parametrize("normalize_input", [False, True])
+def test_dss_raw_bad_channels_are_excluded_and_preserved(normalize_input):
+    """DSS must fit good channels and pass bad Raw channels through unchanged."""
+    rng = np.random.default_rng(43)
+    info = mne.create_info(["EEG0", "EEG1", "EEG2", "EEG3"], 100.0, "eeg")
+    raw = mne.io.RawArray(
+        rng.standard_normal((4, 1000)),
+        info,
+        first_samp=250,
+        verbose=False,
+    )
+    raw.info["bads"] = ["EEG3"]
+    raw.set_annotations(
+        mne.Annotations(
+            onset=[1.0],
+            duration=[0.5],
+            description=["marker"],
+        )
+    )
+
+    dss = DSS(
+        bias=lambda data: data,
+        n_components=3,
+        normalize_input=normalize_input,
+        component_action="retain",
+    ).fit(raw)
+    transformed = dss.transform(raw)
+
+    assert dss._mne_ch_names_ == ["EEG0", "EEG1", "EEG2"]
+    assert dss.filters_.shape == (3, 3)
+    assert transformed.first_samp == raw.first_samp
+    assert transformed.annotations == raw.annotations
+    assert transformed.info["bads"] == raw.info["bads"]
+    assert_allclose(transformed.get_data(picks=["EEG3"]), raw.get_data(picks=["EEG3"]))
+
+
+def test_dss_fit_transform_preserves_bad_raw_channels():
+    """Artifact subtraction must operate only on the fitted good channels."""
+    rng = np.random.default_rng(44)
+    info = mne.create_info(["EEG0", "EEG1", "EEG2", "EEG3"], 100.0, "eeg")
+    raw = mne.io.RawArray(rng.standard_normal((4, 1000)), info, verbose=False)
+    raw.info["bads"] = ["EEG3"]
+
+    cleaned = DSS(
+        bias=lambda data: data,
+        n_components=3,
+        n_select=1,
+        normalize_input=False,
+        component_action="subtract",
+    ).fit_transform(raw)
+
+    assert cleaned.info["bads"] == ["EEG3"]
+    assert_allclose(cleaned.get_data(picks=["EEG3"]), raw.get_data(picks=["EEG3"]))
+
+
+@pytest.mark.parametrize("fit_kws", [{"smooth": 5}, {"whiten": True}])
+def test_dss_alternate_fit_paths_preserve_bad_raw_channels(fit_kws):
+    """Smoothing and whitening must follow the same good-channel contract."""
+    rng = np.random.default_rng(47)
+    info = mne.create_info(["EEG0", "EEG1", "EEG2", "EEG3"], 100.0, "eeg")
+    raw = mne.io.RawArray(rng.standard_normal((4, 1000)), info, verbose=False)
+    raw.info["bads"] = ["EEG3"]
+
+    dss = DSS(
+        bias=lambda data: data,
+        n_components=3,
+        normalize_input=False,
+        component_action="retain",
+        **fit_kws,
+    ).fit(raw)
+    transformed = dss.transform(raw)
+
+    assert dss._mne_ch_names_ == ["EEG0", "EEG1", "EEG2"]
+    assert dss.info_["ch_names"] == dss._mne_ch_names_
+    assert dss.filters_.shape == (3, 3)
+    assert_allclose(transformed.get_data(picks=["EEG3"]), raw.get_data(picks=["EEG3"]))
+
+
+def test_dss_transform_aligns_reordered_mne_channels_by_name():
+    """Transform must align fitted channels by name, independent of input order."""
+    rng = np.random.default_rng(48)
+    info = mne.create_info(["EEG0", "EEG1", "EEG2", "EEG3"], 100.0, "eeg")
+    raw = mne.io.RawArray(rng.standard_normal((4, 1000)), info, verbose=False)
+    raw.info["bads"] = ["EEG3"]
+    reordered = raw.copy().reorder_channels(["EEG2", "EEG0", "EEG3", "EEG1"])
+
+    dss = DSS(
+        bias=lambda data: data,
+        n_components=3,
+        normalize_input=False,
+        component_action="retain",
+    ).fit(raw)
+    transformed = dss.transform(reordered)
+
+    assert transformed.ch_names == reordered.ch_names
+    assert_allclose(transformed.get_data(), reordered.get_data(), atol=1e-12)
+
+
+def test_dss_transform_rejects_missing_fitted_channel():
+    """Missing fitted channels must raise an actionable error."""
+    rng = np.random.default_rng(49)
+    info = mne.create_info(["EEG0", "EEG1", "EEG2"], 100.0, "eeg")
+    raw = mne.io.RawArray(rng.standard_normal((3, 1000)), info, verbose=False)
+    dss = DSS(bias=lambda data: data, normalize_input=False).fit(raw)
+
+    with pytest.raises(ValueError, match="missing required channels.*EEG2"):
+        dss.transform(raw.copy().drop_channels(["EEG2"]))
+
+
+def test_dss_fit_rejects_all_bad_data_channels():
+    """DSS must fail clearly when no usable fitted channels remain."""
+    rng = np.random.default_rng(50)
+    info = mne.create_info(["EEG0", "EEG1"], 100.0, "eeg")
+    raw = mne.io.RawArray(rng.standard_normal((2, 1000)), info, verbose=False)
+    raw.info["bads"] = raw.ch_names
+
+    with pytest.raises(ValueError, match="No good data channels remain"):
+        DSS(bias=lambda data: data, normalize_input=False).fit(raw)
+
+
+def test_dss_epochs_bad_channels_are_excluded_and_preserved():
+    """DSS must preserve bad Epochs channels and epoch bookkeeping."""
+    pd = pytest.importorskip("pandas")
+    rng = np.random.default_rng(45)
+    info = mne.create_info(["EEG0", "EEG1", "EEG2", "EEG3"], 100.0, "eeg")
+    events = np.column_stack(
+        [np.arange(5) * 100, np.zeros(5, dtype=int), np.ones(5, dtype=int)]
+    )
+    epochs = mne.EpochsArray(
+        rng.standard_normal((5, 4, 100)),
+        info,
+        events=events,
+        event_id={"stim": 1},
+        verbose=False,
+    )
+    epochs.info["bads"] = ["EEG3"]
+    epochs.metadata = pd.DataFrame({"condition": list("abcde")})
+
+    dss = DSS(
+        bias=lambda data: data,
+        n_components=3,
+        normalize_input=False,
+        component_action="retain",
+    ).fit(epochs)
+    transformed = dss.transform(epochs)
+
+    assert dss._mne_ch_names_ == ["EEG0", "EEG1", "EEG2"]
+    assert dss.filters_.shape == (3, 3)
+    assert transformed.info["bads"] == epochs.info["bads"]
+    assert_allclose(
+        transformed.get_data(picks=["EEG3"]), epochs.get_data(picks=["EEG3"])
+    )
+    assert_allclose(transformed.events, epochs.events)
+    assert transformed.event_id == epochs.event_id
+    assert transformed.metadata.equals(epochs.metadata)
+
+
+def test_dss_evoked_bad_channels_are_excluded_and_preserved():
+    """The NumPy Evoked path must honor the same fitted-channel contract."""
+    rng = np.random.default_rng(46)
+    info = mne.create_info(["EEG0", "EEG1", "EEG2", "EEG3"], 100.0, "eeg")
+    evoked = mne.EvokedArray(
+        rng.standard_normal((4, 500)),
+        info,
+        tmin=-0.2,
+        comment="condition",
+        nave=17,
+        verbose=False,
+    )
+    evoked.info["bads"] = ["EEG3"]
+
+    dss = DSS(
+        bias=lambda data: data,
+        n_components=3,
+        normalize_input=False,
+        component_action="retain",
+    ).fit(evoked)
+    transformed = dss.transform(evoked)
+
+    assert dss._mne_ch_names_ == ["EEG0", "EEG1", "EEG2"]
+    assert dss.filters_.shape == (3, 3)
+    assert transformed.info["bads"] == evoked.info["bads"]
+    assert transformed.comment == evoked.comment
+    assert transformed.nave == evoked.nave
+    assert_allclose(
+        transformed.get_data(picks=["EEG3"]), evoked.get_data(picks=["EEG3"])
+    )
+
+
 def test_dss_reconstruction_preserves_signal():
     """DSS transform + inverse_transform should preserve signal content."""
     rng = np.random.default_rng(42)
@@ -1030,7 +1271,10 @@ def test_dss_preserves_scale():
 
     bias = IdentityBias()
     dss = DSS(
-        bias=bias, n_components=n_channels, normalize_input=False, return_type="raw"
+        bias=bias,
+        n_components=n_channels,
+        normalize_input=False,
+        component_action="retain",
     )
     reconstructed = dss.fit_transform(data)
 
@@ -1131,7 +1375,7 @@ def test_dss_whiten_reconstruction_is_faithful_across_units():
     raw, _, data = _mixed_sensor_raw()
     bias = BandpassBias(freq_band=(8, 12), sfreq=raw.info["sfreq"])
 
-    dss = DSS(bias=bias, whiten=True, return_type="raw").fit(raw)
+    dss = DSS(bias=bias, whiten=True, component_action="retain").fit(raw)
     rec = dss.transform(raw).get_data()
 
     rel_error = np.linalg.norm(rec - data) / np.linalg.norm(data)
@@ -1175,7 +1419,7 @@ def test_dss_whiten_epochs():
     epochs = mne.EpochsArray(epoch_data, raw.info, verbose=False)
 
     bias = BandpassBias(freq_band=(8, 12), sfreq=raw.info["sfreq"])
-    dss = DSS(bias=bias, whiten=True, return_type="epochs").fit(epochs)
+    dss = DSS(bias=bias, whiten=True, component_action="retain").fit(epochs)
     rec = dss.transform(epochs).get_data()
 
     assert rec.shape == epoch_data.shape
@@ -1282,7 +1526,7 @@ def test_dss_whiten_inverse_transform_recovers_sensor_data():
 
     raw, _, data = _mixed_sensor_raw()
     bias = BandpassBias(freq_band=(8, 12), sfreq=raw.info["sfreq"])
-    dss = DSS(bias=bias, whiten=True, return_type="sources").fit(raw)
+    dss = DSS(bias=bias, whiten=True, component_action="extract").fit(raw)
 
     sources = dss.transform(raw)
     rec = dss.inverse_transform(sources)
@@ -1344,7 +1588,7 @@ class TestSegmentedDSS:
         """
         data = np.random.default_rng(0).standard_normal((8, 5000))
         bias = LineNoiseBias(freq=50.0, sfreq=250.0)
-        dss = DSS(bias, adaptive=True, n_components=2)
+        dss = DSS(bias, component_action="subtract", adaptive=True, n_components=2)
         dss.fit(data)
         assert dss.filters_ is not None
         assert dss.filters_.shape == (2, 8)
@@ -1357,7 +1601,12 @@ class TestSegmentedDSS:
             return x
 
         data = np.random.default_rng(0).standard_normal((8, 5000))
-        dss = DSS(bias_without_sfreq, adaptive=True, n_components=2)
+        dss = DSS(
+            bias_without_sfreq,
+            component_action="subtract",
+            adaptive=True,
+            n_components=2,
+        )
         with pytest.raises(ValueError, match="sfreq"):
             dss.fit_transform(data)
 
@@ -1367,6 +1616,7 @@ class TestSegmentedDSS:
         dss = DSS(
             bias,
             adaptive=True,
+            component_action="subtract",
             n_components=2,
             reg=1e-7,
             normalize_input=False,
@@ -1391,6 +1641,7 @@ class TestSegmentedDSS:
         dss = DSS(
             bias,
             adaptive=True,
+            component_action="subtract",
             segmenter=FixedWindowSegmenter(sfreq=sfreq, window_len=30.0),
             n_components=2,
         )
@@ -1406,6 +1657,7 @@ class TestSegmentedDSS:
         dss = DSS(
             bias,
             adaptive=True,
+            component_action="subtract",
             segmenter=FixedWindowSegmenter(sfreq=sfreq, window_len=30.0),
             n_components=2,
         )
@@ -1422,6 +1674,7 @@ class TestSegmentedDSS:
         dss = DSS(
             bias,
             adaptive=True,
+            component_action="subtract",
             segmenter=FixedWindowSegmenter(sfreq=sfreq, window_len=30.0),
             n_components=4,
             n_select="auto",
@@ -1441,6 +1694,7 @@ class TestSegmentedDSS:
         dss = DSS(
             bias,
             adaptive=True,
+            component_action="subtract",
             segmenter=FixedWindowSegmenter(sfreq=sfreq, window_len=30.0),
             n_components=4,
             n_select=1,
@@ -1467,6 +1721,7 @@ class TestSegmentedDSS:
         dss = DSS(
             bias,
             adaptive=True,
+            component_action="subtract",
             segmenter=CovarianceSegmenter(sfreq=sfreq, min_chunk_len=20.0),
             n_components=2,
         )
@@ -1498,7 +1753,7 @@ class TestSegmentedDSS:
             verbose=False,
         )
         bias = LineNoiseBias(freq=50.0, sfreq=sfreq)
-        dss = DSS(bias, adaptive=True, n_components=2)
+        dss = DSS(bias, component_action="subtract", adaptive=True, n_components=2)
         # Epochs should either work (segmentation on concatenated) or raise
         try:
             dss.fit_transform(epochs)
@@ -1602,7 +1857,7 @@ class TestSmoothingDecomposition:
         info = mne.create_info(data.shape[0], sfreq, ch_types="eeg")
         raw = mne.io.RawArray(data, info, verbose=False)
         bias = LineNoiseBias(freq=50.0, sfreq=sfreq)
-        dss = DSS(bias, n_components=2, smooth=5, return_type="raw")
+        dss = DSS(bias, n_components=2, smooth=5, component_action="retain")
         dss.fit(raw)
         result = dss.transform(raw)
         result_data = result.get_data()
@@ -1622,6 +1877,7 @@ class TestSmoothingDecomposition:
         dss = DSS(
             bias,
             adaptive=True,
+            component_action="subtract",
             segmenter=FixedWindowSegmenter(sfreq=sfreq, window_len=30.0),
             n_components=4,
             n_select=1,
@@ -1661,6 +1917,7 @@ class TestCapAndFloor:
         dss = DSS(
             bias,
             adaptive=True,
+            component_action="subtract",
             segmenter=FixedWindowSegmenter(sfreq=sfreq, window_len=30.0),
             n_components=10,
             n_select="auto",
@@ -1680,6 +1937,7 @@ class TestCapAndFloor:
         dss = DSS(
             bias,
             adaptive=True,
+            component_action="subtract",
             segmenter=FixedWindowSegmenter(sfreq=sfreq, window_len=30.0),
             n_components=4,
             n_select="auto",
@@ -1702,6 +1960,7 @@ class TestCrossfade:
         dss = DSS(
             bias,
             adaptive=True,
+            component_action="subtract",
             segmenter=FixedWindowSegmenter(sfreq=sfreq, window_len=30.0),
             crossfade=1.0,
             n_components=4,
@@ -1721,6 +1980,7 @@ class TestCrossfade:
         dss_hard = DSS(
             bias,
             adaptive=True,
+            component_action="subtract",
             segmenter=FixedWindowSegmenter(sfreq=sfreq, window_len=30.0),
             crossfade=0.0,
             n_components=4,
@@ -1732,6 +1992,7 @@ class TestCrossfade:
         dss_xfade = DSS(
             bias,
             adaptive=True,
+            component_action="subtract",
             segmenter=FixedWindowSegmenter(sfreq=sfreq, window_len=30.0),
             crossfade=1.0,
             n_components=4,
@@ -1775,6 +2036,7 @@ class TestCrossfade:
         dss_hard = DSS(
             bias,
             adaptive=True,
+            component_action="subtract",
             segmenter=seg,
             crossfade=0.0,
             n_components=4,
@@ -1783,6 +2045,7 @@ class TestCrossfade:
         dss_xfade = DSS(
             bias,
             adaptive=True,
+            component_action="subtract",
             segmenter=seg,
             crossfade=1.0,
             n_components=4,
@@ -1803,6 +2066,7 @@ class TestCrossfade:
         dss = DSS(
             bias,
             adaptive=True,
+            component_action="subtract",
             segmenter=seg,
             n_components=4,
             n_select="auto",
@@ -1813,6 +2077,7 @@ class TestCrossfade:
         dss0 = DSS(
             bias,
             adaptive=True,
+            component_action="subtract",
             segmenter=seg,
             crossfade=0.0,
             n_components=4,
@@ -1831,6 +2096,7 @@ class TestCrossfade:
         dss = DSS(
             bias,
             adaptive=True,
+            component_action="subtract",
             segmenter=FixedWindowSegmenter(sfreq=sfreq, window_len=30.0),
             crossfade=1.0,
             n_components=4,
@@ -1858,6 +2124,7 @@ class TestCrossfade:
         dss = DSS(
             bias,
             adaptive=True,
+            component_action="subtract",
             segmenter=FixedWindowSegmenter(sfreq=sfreq, window_len=10.0),
             crossfade=8.0,  # way too long
             n_components=4,
@@ -1943,7 +2210,7 @@ def test_get_normalized_patterns_returns_unit_columns():
 
 
 def test_fit_transform_subtracts_selected_components():
-    """Non-adaptive fit_transform with a non-'sources' return_type cleans."""
+    """Explicit subtraction removes selected components."""
     sfreq = 250.0
     n_times = int(20 * sfreq)
     t = np.arange(n_times) / sfreq
@@ -1952,7 +2219,7 @@ def test_fit_transform_subtracts_selected_components():
     data += np.sin(2 * np.pi * 50.0 * t) * 4.0
 
     bias = LineNoiseBias(freq=50.0, sfreq=sfreq)
-    dss = DSS(bias, n_select=2, return_type="raw")
+    dss = DSS(bias, n_select=2, component_action="subtract")
     cleaned = dss.fit_transform(data)
 
     assert cleaned.shape == data.shape
@@ -1966,7 +2233,7 @@ def test_fit_transform_without_selection_is_passthrough():
     rng = np.random.default_rng(0)
     data = rng.standard_normal((6, 2000))
 
-    dss = DSS(bias=lambda x: x, return_type="raw")
+    dss = DSS(bias=lambda x: x, component_action="subtract")
     cleaned = dss.fit_transform(data)
 
     assert dss.n_selected_ is None
@@ -1981,7 +2248,9 @@ def test_empty_segmentation_raises():
     rng = np.random.default_rng(0)
     data = rng.standard_normal((6, 5000))
     bias = LineNoiseBias(freq=50.0, sfreq=250.0)
-    dss = DSS(bias, adaptive=True, segmenter=EmptySegmenter())
+    dss = DSS(
+        bias, component_action="subtract", adaptive=True, segmenter=EmptySegmenter()
+    )
 
     with pytest.raises(ValueError, match="no segments"):
         dss.fit_transform(data)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -66,6 +66,36 @@ def test_extract_data_from_mne_all_data_channels():
     assert ch_names == ["MAG", "GRAD", "EEG"]
 
 
+def test_extract_data_from_mne_can_exclude_bads():
+    """Automatic extraction can establish a good-channel fitted contract."""
+    info = mne.create_info(["C1", "C2", "C3"], 100.0, "eeg")
+    raw = mne.io.RawArray(np.arange(300).reshape(3, 100), info, verbose=False)
+    raw.info["bads"] = ["C2"]
+
+    data, _, _, _, picks, ch_names = extract_data_from_mne(raw, exclude_bads=True)
+
+    np.testing.assert_array_equal(picks, [0, 2])
+    np.testing.assert_array_equal(data, raw.get_data(picks=[0, 2]))
+    assert ch_names == ["C1", "C3"]
+
+
+def test_extract_data_from_mne_explicit_names_override_bad_exclusion():
+    """Explicit names remain authoritative when applying a fitted contract."""
+    info = mne.create_info(["C1", "C2"], 100.0, "eeg")
+    raw = mne.io.RawArray(np.ones((2, 100)), info, verbose=False)
+    raw.info["bads"] = ["C2"]
+
+    data, _, _, _, picks, ch_names = extract_data_from_mne(
+        raw,
+        ch_names=["C2"],
+        exclude_bads=True,
+    )
+
+    np.testing.assert_array_equal(picks, [1])
+    assert data.shape == (1, 100)
+    assert ch_names == ["C2"]
+
+
 def test_extract_data_from_mne_epoch_layout_options_are_exclusive():
     """Epoch concatenation and channel-first 3D output cannot be requested together."""
     with pytest.raises(ValueError, match="cannot both be True"):

--- a/tests/viz/conftest.py
+++ b/tests/viz/conftest.py
@@ -32,7 +32,7 @@ def fitted_dss(synthetic_data):
     def bias_func(d):
         return mne.filter.filter_data(d, 100.0, 8, 12, verbose=False)
 
-    dss = DSS(n_components=3, bias=bias_func, return_type="epochs")
+    dss = DSS(n_components=3, bias=bias_func, component_action="retain")
     dss.fit(synthetic_data)
     return dss
 


### PR DESCRIPTION
  - handle bad channels consistently for Raw, Epochs, and Evoked inputs
  - preserve Raw annotations, sample coordinates, projections, and untouched channels
  - replace the legacy `return_type` API with explicit `component_action={"extract", "retain", "subtract"}`
  - preserve true segmented processing for adaptive DSS subtraction
  - update documentation, examples, changelog entries, and regression tests

  This is based directly on current `main` and supersedes #56 (avoiding conflict and unnecessary changes) , which we’ll close after this PR is merged.