### PR TITLE
feat(dss): add validated time-shift DSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - **Linear DSS**: Extract components based on reproducibility across trials or characteristic frequencies
 - **Iterative DSS**: Powerful nonlinear separation for complex non-Gaussian sources
 - **20+ Pluggable Denoisers**: Spectral, temporal, periodic, and ICA-style bias functions
-- **Specialized Variants**: TSR, SSVEP enhancement, narrowband oscillation extraction
+- **Specialized Variants**: TimeShiftDSS, SSVEP enhancement, and narrowband oscillation extraction
 
 ### ZapLine Module
 
@@ -137,11 +137,11 @@ mne_denoise/
 │   ├── nonlinear.py        # Iterative DSS, IterativeDSS estimator
 │   ├── denoisers/          # 20+ pluggable bias functions
 │   │   ├── spectral.py     # BandpassBias, LineNoiseBias
-│   │   ├── temporal.py     # TimeShiftBias, SmoothingBias
+│   │   ├── temporal.py     # LagAverageBias, SmoothingBias
 │   │   ├── periodic.py     # CombFilterBias, PeakFilterBias
 │   │   └── ...
 │   └── variants/           # Pre-built applications
-│       ├── tsr.py          # Time-Shift Repeatability
+│       ├── tsr.py          # Time-shift DSS and temporal smoothing
 │       ├── ssvep.py        # SSVEP enhancement
 │       └── narrowband.py   # Oscillation extraction
 ├── zapline/                # Line noise removal

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -33,6 +33,7 @@ DSS
 
    mne_denoise.dss.compute_dss
    mne_denoise.dss.DSS
+   mne_denoise.dss.TimeShiftDSS
    mne_denoise.dss.iterative_dss
    mne_denoise.dss.IterativeDSS
 
@@ -110,7 +111,7 @@ Denoisers
    mne_denoise.dss.denoisers.LineNoiseBias
    mne_denoise.dss.denoisers.PeakFilterBias
    mne_denoise.dss.denoisers.CombFilterBias
-   mne_denoise.dss.denoisers.TimeShiftBias
+   mne_denoise.dss.denoisers.LagAverageBias
    mne_denoise.dss.denoisers.SmoothingBias
    mne_denoise.dss.denoisers.SpectrogramBias
    mne_denoise.dss.denoisers.NonlinearDenoiser
@@ -130,12 +131,10 @@ Variants
    :toctree: generated/
    :nosignatures:
 
-   mne_denoise.dss.variants.time_shift_dss
    mne_denoise.dss.variants.smooth_dss
    mne_denoise.dss.variants.narrowband_dss
    mne_denoise.dss.variants.narrowband_scan
    mne_denoise.dss.variants.ssvep_dss
-   mne_denoise.dss.variants.tsr
 
 Quality Assurance
 -----------------

--- a/docs/changes/devel/70.bugfix.rst
+++ b/docs/changes/devel/70.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed 3-D covariance and ``AverageBias`` weights to follow time-by-epoch
+observation order, and made ``DSS`` transforms reuse their fitted global mean.

--- a/docs/changes/devel/70.feature.rst
+++ b/docs/changes/devel/70.feature.rst
@@ -1,0 +1,3 @@
+Added ``TimeShiftDSS`` for explicit lag-augmented repeated-trial DSS, with
+weighted fitting, held-out scoring, sensor reconstruction, optional CCA
+distortion control, and a scientific validation script.

--- a/docs/changes/devel/70.misc.rst
+++ b/docs/changes/devel/70.misc.rst
@@ -1,0 +1,2 @@
+Shared weighted CCA, sensor-mixing, and positive-integer validation helpers
+across DSS, BSS-CCA, and SSA.

--- a/docs/changes/devel/70.removal.rst
+++ b/docs/changes/devel/70.removal.rst
@@ -1,0 +1,2 @@
+Renamed ``TimeShiftBias`` to ``LagAverageBias`` and removed the ambiguous
+``time_shift_dss()`` convenience constructor.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ to extract reproducible or rhythmic components while preserving data rank.
 
    getting-started
    dss
+   time_shift_dss
    asr
    bss_cca
    sns

--- a/docs/time_shift_dss.md
+++ b/docs/time_shift_dss.md
@@ -1,0 +1,233 @@
+# TimeShiftDSS
+
+```{warning}
+`TimeShiftDSS` has substantially more free parameters than spatial DSS. Do not
+interpret, retain, or remove a component without held-out and surrogate
+validation.
+```
+
+## What it adds to trial-average DSS
+
+Ordinary DSS learns an instantaneous spatial filter:
+
+\[
+y_k(t) = \sum_j a_{kj} x_j(t).
+\]
+
+Time-shift DSS first treats delayed copies of every sensor as additional
+features and then fits the existing estimator as
+`DSS(bias=AverageBias(axis="epochs"))`:
+
+\[
+y_k(t) = \sum_{j,d} a_{kjd} x_j(t-d).
+\]
+
+The resulting component is a multichannel finite-impulse-response filter. This
+can separate a reproducible target from interference that overlaps it in the
+instantaneous sensor space but differs in delay, propagation, or spectrum.
+It is not the package's multi-dataset Joint DSS mode. Joint DSS uses
+`AverageBias(axis="datasets")`; TimeShiftDSS uses trial averaging after lag
+augmentation.
+
+The initial package implementation deliberately supports only repeated-trial
+data: a NumPy array shaped `(channels, times, epochs)` or MNE `Epochs`. Raw and
+Evoked inputs and arbitrary DSS bias functions are outside the source-validated
+contract.
+
+## Explicit fit
+
+```python
+from mne_denoise.dss import TimeShiftDSS
+
+tsdss = TimeShiftDSS(
+    lag_samples=[0, 1],
+    rank=16,
+    n_components=2,
+    n_select=1,
+    component_action="extract",
+)
+sources = tsdss.fit_transform(epochs)
+```
+
+Positive lag `d` contributes `X(t - d)`. Lags are explicit, include zero, and
+are applied separately inside each epoch. Only the time interval shared by all
+lags is fitted or extracted. Sensor-valued `retain` and `subtract` operations
+keep the original container and timeline and leave edge samples outside that
+interval unchanged.
+
+The 2010 paper defines delays as `0, ..., D - 1` but describes its one-sample
+delayed-noise simulation as `D = 1`. The package therefore does not expose this
+ambiguous shorthand: the reproduction declares `[0, 1]` explicitly.
+
+## Source-derived algorithm
+
+The implementation maps the paper's steps as follows.
+
+| Source claim | Package implementation | Blocking tests/evidence |
+| --- | --- | --- |
+| 1. Add delayed sensor copies | Lag-major `_lag_augment` with equation `X(t-d)` | Exact lag sign, valid support, and epoch-isolation tests |
+| 2. Concatenate trial observations | C-order `(feature, time, epoch)` flattening | Unequal weight-order regression tests |
+| 3. PCA and normalize | Internal `DSS` estimator and its canonical covariance whitener | Existing DSS/NoiseTools parity plus full-rank reconstruction |
+| 4. Average across trials | Shared `AverageBias(axis="epochs")`, including time-by-epoch weights | Uniform and time-by-epoch weight tests |
+| 5. PCA of biased data | Internal `DSS` estimator's biased-covariance rotation | Component ordering and held-out score tests |
+| 6. Apply rotation | Frozen lag-space filters | Transform-batch invariance tests |
+| 7. Optional CCA | Shared training-only `canonical_correlation` inside the selected reproducible subspace | Shifted-waveform distortion fixture |
+| Zero-weight outliers | Minimum weight across every sample touched by a lag window | Lag-window mask-dilation test |
+| Relative PCA cutoff | Explicit rank and relative `reg` tolerance | Rank and source-simulation sensitivity sweep |
+| Resampling and CV | Whole-trial bootstrap, grouped CV, nested CV, and max-null surrogates | Reduced CI fixtures and checked validation script |
+
+Primary sources:
+
+- [de Cheveigne (2010), Time-shift denoising source separation](https://doi.org/10.1016/j.jneumeth.2010.03.002)
+- [de Cheveigne and Parra (2014), Joint denoising source separation](https://doi.org/10.1016/j.neuroimage.2014.05.068)
+
+## Centering and covariance weights
+
+The source/reference-aligned default is `center=False`: DSS is fitted from
+uncentered second moments. This preserves meaningful baseline correction. It
+also avoids the trial-wise mean removal that the 2014 review shows can create a
+repeatable ramp.
+
+`center=True` is a package extension. It fits one weighted global mean of the
+valid augmented training observations, stores `feature_mean_`, and uses that
+same mean for every later transform. It never computes a transform-batch or
+per-epoch mean.
+
+`fit(..., sample_weight=weights)` accepts either `(n_times,)` weights broadcast
+over epochs or an exact `(n_times, n_epochs)` matrix. Weights must be finite and
+nonnegative. For each valid reference observation, the effective weight is the
+minimum across all source samples touched by its lag window. A zero-weight bad
+sample therefore invalidates every augmented observation containing it.
+
+For augmented observations \(z_{t,n}\), the repeated-trial contrast is
+
+\[
+\bar z_t =
+\frac{\sum_n w_{t,n} z_{t,n}}{\sum_n w_{t,n}}.
+\]
+
+The baseline second moment uses all valid `(time, epoch)` observations. The
+biased second moment uses \(\bar z_t\), weighted by the valid trial mass
+\(\sum_n w_{t,n}\). The two matrices use identical lag support.
+
+## Explicit rank and component choice
+
+TimeShiftDSS does not offer `"auto"` selection. Callers provide `rank`,
+`n_components`, and, for sensor operations, `n_select`. The fitted object
+reports:
+
+- `n_augmented_features_`;
+- `positive_weight_observations_`; and
+- `effective_observations_`, using the Kish weight formula.
+
+A warning is raised when augmented dimension approaches the effective weighted
+observation count. This ratio is only a heuristic: autocorrelated samples supply
+fewer independent constraints than their count suggests.
+
+The source simulation has a real rank cliff. In Simulation 2 with explicit
+lags `[0, 1]`, five noise sources enter the augmented covariance at three time
+states. A rank that keeps only those 15 noise directions omits the target;
+admitting the next direction makes temporal cancellation possible. Rank and
+lag sensitivity must therefore be reported, not tuned on the final test set.
+
+## Held-out and null validation
+
+Use sklearn splitters on explicit epoch indices. NumPy TSDSS data are
+channel-first with epochs on the last axis, so passing the array directly to
+`sklearn.model_selection.cross_validate` would incorrectly split channels.
+For example:
+
+```python
+import numpy as np
+from sklearn.base import clone
+from sklearn.model_selection import GroupKFold
+
+fold_scores = []
+epoch_indices = np.arange(data.shape[2])
+splitter = GroupKFold(n_splits=5)
+for train, test in splitter.split(epoch_indices, groups=run_ids):
+    fitted = clone(tsdss).fit(data[:, :, train])
+    fold_scores.append(fitted.score(data[:, :, test]))
+
+held_out_score = np.mean(fold_scores)
+```
+
+`TimeShiftDSS.score` requires an explicit `n_select` and returns one
+trial-average-to-total power ratio for that leading component subspace. This
+avoids comparing component ordinals that can reorder across folds and aligns
+validation with the cumulative subspace used by `retain` and `subtract`.
+
+For MNE Epochs, use the same splitter and replace `data[:, :, indices]` with
+`epochs[indices]`. Means, weights, covariances, filters, and optional CCA must
+be fitted on the training fold only.
+
+The repository's checked scientific QA additionally calibrates one predeclared
+model against circularly shifted trials. This procedure lives in
+`scripts/validate_time_shift_dss.py`, not in the installed denoising API. It
+shifts every complete multichannel epoch independently by more than the lag
+span, preserving its within-epoch structure while destroying trial locking.
+
+If lags, rank, or subspace size are tuned from the same data, use sklearn nested
+cross-validation and repeat that exact search inside every surrogate; otherwise
+the null distribution does not include search multiplicity. Continuous
+event-marker randomization from the 2014 paper remains a future Raw/event-data
+extension. Bootstrap uncertainty is likewise kept in the checked validation
+script rather than duplicated as package API.
+
+## Reconstruction and distortion
+
+Standard sensor reconstruction is a weighted least-squares projection of
+fitted component activity to the undelayed sensor block. It is tested directly
+and reconstructs the valid interval at full rank.
+
+The optional `distortion_control="cca"` implements the paper's step 7. It takes
+the explicitly fitted reproducible subspace and learns the single combination
+most correlated with undelayed training sensors. The rotation, component mean,
+and sensor mean are frozen before held-out transformation. It can reduce FIR
+latency and waveform distortion, but it trades repeatability for similarity and
+adds another fitted operation that must stay inside validation folds.
+
+## Scientific validation
+
+Paper parity, efficacy, and null-calibration checks belong in the scientific
+validation workflow rather than the package unit tests. Run it with:
+
+```bash
+python scripts/validate_time_shift_dss.py
+```
+
+It records seeds and dependency versions and writes JSON, CSV, and PNG evidence
+under `reports/time_shift_dss/` by default. The script includes:
+
+- the 2010 Simulation 2 dimensions: 10 channels, 1000 samples, 100 trials, and
+  input SNRs of -20, -40, and -60 dB;
+- held-out static-DSS versus TimeShiftDSS output SNR, gain, correlation, latency,
+  distortion, and noise attenuation;
+- rank and lag-grid sensitivity;
+- 100 whole-training-set bootstrap refits with a fixed held-out test set;
+- 1000 full-pipeline pure-noise surrogates; and
+- the Figure 6 shifted-waveform failure with and without CCA step 7.
+
+`--quick` reduces the repetitions for a local smoke run. It is marked as such
+and is not parity evidence. The default run applies predeclared acceptance
+gates and exits unsuccessfully if any gate fails. Generated reports are review
+artifacts and are intentionally not embedded in the API documentation.
+
+## Interpretation and limitations
+
+- An evoked trial-average contrast retains reproducible activity. It cannot
+  decide whether that activity is neural or artifactual.
+- Retaining the leading target component intentionally suppresses off-target
+  activity, including genuine non-target neural signals. The validation report
+  quantifies this rather than calling the operation generally signal
+  preserving.
+- Components define optimized subspaces, not individual neural sources.
+- Preserved edge samples are not FIR-filtered and are excluded from efficacy
+  metrics.
+- The epoched circular-shift null is a package extension, not the continuous
+  random-event surrogate used in the 2014 paper.
+- Arbitrary lag grids, optional centering, weighted/regularized CCA, and the
+  high-dimensional warning threshold are package contracts rather than claims
+  made by the 2010 paper.
+- Apply one fitted transform to all study conditions. Fitting each
+  condition separately can manufacture apparent condition differences.

--- a/examples/dss/plot_06_temporal_dss.py
+++ b/examples/dss/plot_06_temporal_dss.py
@@ -1,15 +1,18 @@
 """
 =================================================
-Temporal DSS: Time-Shift Regression & Smoothness.
+Temporal Biases for Ordinary DSS.
 =================================================
 
 This example demonstrates DSS for extracting **temporally structured** signals:
 autocorrelated components, slow drifts, and smooth waveforms.
 
-We cover both **linear biases** (TimeShiftBias, SmoothingBias) and
+These ordinary-DSS bias operators do not perform lag-space ``TimeShiftDSS``;
+see the dedicated TimeShiftDSS guide for that repeated-trial FIR estimator.
+
+We cover both **linear biases** (LagAverageBias, SmoothingBias) and
 **nonlinear denoisers** (DCTDenoiser, TemporalSmoothnessDenoiser).
 
-The examples move from synthetic slow drifts to time-shift and smoothing
+The examples move from synthetic slow drifts to lag-averaging and smoothing
 biases, then to DCT-based iterative denoising and a real EEG slow-potential
 example.
 
@@ -29,10 +32,10 @@ from scipy import signal
 from mne_denoise.dss import DSS, IterativeDSS
 from mne_denoise.dss.denoisers import (
     DCTDenoiser,
+    LagAverageBias,
     SmoothingBias,
-    TimeShiftBias,
 )
-from mne_denoise.dss.variants import smooth_dss, time_shift_dss
+from mne_denoise.dss.variants import smooth_dss
 from mne_denoise.viz import (
     plot_channel_time_course_comparison,
     plot_component_summary,
@@ -116,27 +119,20 @@ plt.show()
 
 
 # %%
-# Part 1: Time-Shift Regression (TimeShiftBias)
+# Part 1: Lag-averaging bias
 # ==============================================
-# TSR finds components that are autocorrelated across time lags
+# Lag averaging emphasizes components that remain similar across time lags.
 
-print("\n--- Part 1: Time-Shift Regression ---")
+print("\n--- Part 1: Lag Averaging ---")
 
-# Manual TimeShiftBias
-bias_tsr = TimeShiftBias(shifts=10, method="autocorrelation")
+# Explicit lag-averaging bias
+bias_tsr = LagAverageBias(lags=10, weighting="uniform")
 dss_tsr_manual = DSS(n_components=5, bias=bias_tsr)
 dss_tsr_manual.fit(raw_sim)
 
 print(f"Manual DSS Eigenvalues: {dss_tsr_manual.eigenvalues_[:5]}")
 
-# Wrapper for comparison
-dss_tsr_wrapper = time_shift_dss(shifts=10, n_components=5)
-dss_tsr_wrapper.fit(raw_sim)
-
-print(f"Wrapper Eigenvalues: {dss_tsr_wrapper.eigenvalues_[:5]}")
-print("(Should be identical)")
-
-# Use manual for visualization
+# Visualize the explicit DSS-plus-bias configuration
 plot_component_summary(
     dss_tsr_manual,
     data=raw_sim,
@@ -145,7 +141,7 @@ plot_component_summary(
     n_components=3,
     show=False,
 )
-plt.gcf().suptitle("TimeShiftBias (TSR): Autocorrelated Components")
+plt.gcf().suptitle("LagAverageBias: Temporally Smooth Components")
 plt.show()
 
 # %%
@@ -169,12 +165,12 @@ plt.plot(
     comp0_tsr[:2000] * (np.std(drift) / np.std(comp0_tsr)),
     "r",
     linewidth=1.5,
-    label=f"TSR Component 0 (r={corr_tsr:.3f})",
+    label=f"Lag-average component 0 (r={corr_tsr:.3f})",
     alpha=0.8,
 )
 plt.xlabel("Time (s)")
 plt.ylabel("Amplitude (scaled)")
-plt.title("Time-Shift Regression: Extracted Slow Drift")
+plt.title("Lag Averaging: Extracted Slow Drift")
 plt.legend()
 plt.grid(True, alpha=0.3)
 plt.tight_layout()
@@ -279,8 +275,13 @@ axes[0].set_ylabel("Amplitude")
 axes[0].legend()
 axes[0].grid(True, alpha=0.3)
 
-axes[1].plot(t_compare, comp0_tsr[:2000] * scale, "r", label=f"TSR (r={corr_tsr:.3f})")
-axes[1].set_title("TimeShiftBias (Time-Shift Regression)")
+axes[1].plot(
+    t_compare,
+    comp0_tsr[:2000] * scale,
+    "r",
+    label=f"Lag average (r={corr_tsr:.3f})",
+)
+axes[1].set_title("LagAverageBias")
 axes[1].set_ylabel("Amplitude")
 axes[1].legend()
 axes[1].grid(True, alpha=0.3)
@@ -311,7 +312,7 @@ print("\n--- All methods successfully extract the slow drift ---")
 # %%
 # Part 4: Real EEG Data (Slow Cortical Potentials)
 # =================================================
-# Apply TSR to real EEG for slow drift extraction
+# Apply lag-averaging DSS to real EEG for slow drift extraction
 
 print("\n--- Part 4: Real EEG Data ---")
 
@@ -342,11 +343,11 @@ raw_eeg.crop(0, 30)  # 30 seconds
 
 print(f"EEG Data: {len(raw_eeg.ch_names)} channels, {raw_eeg.times[-1]:.1f}s")
 
-# Apply TSR
-dss_eeg_tsr = time_shift_dss(shifts=10, n_components=5)
+# Apply lag-averaging DSS
+dss_eeg_tsr = DSS(bias=LagAverageBias(lags=10), n_components=5)
 dss_eeg_tsr.fit(raw_eeg)
 
-print(f"\nTSR Eigenvalues: {dss_eeg_tsr.eigenvalues_[:5]}")
+print(f"\nLag-average eigenvalues: {dss_eeg_tsr.eigenvalues_[:5]}")
 
 # Get sources for visualization
 sources_eeg = dss_eeg_tsr.transform(raw_eeg)
@@ -366,7 +367,7 @@ plot_channel_time_course_comparison(
     stop=int(10 * raw_single.info["sfreq"]),
     show=False,
 )
-plt.gcf().suptitle("Real EEG: Original vs TSR Component 0")
+plt.gcf().suptitle("Real EEG: Original vs Lag-Average Component 0")
 plt.show()
 
 # %%
@@ -374,4 +375,4 @@ plot_psd_comparison(raw_single, comp_raw, fmin=0.1, fmax=10, show=False)
 plt.gcf().axes[0].set_title("Real EEG: PSD Comparison (Slow Oscillations)")
 plt.show()
 
-print("\nTSR successfully extracted slow cortical potentials from real EEG!")
+print("\nLag-averaging DSS extracted slow cortical potentials from real EEG!")

--- a/mne_denoise/_cca.py
+++ b/mne_denoise/_cca.py
@@ -34,6 +34,9 @@ from scipy import linalg as la
 def canonical_correlation(
     X: np.ndarray,
     Y: np.ndarray,
+    *,
+    sample_weight: np.ndarray | None = None,
+    rtol: float | None = None,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     r"""Compute canonical correlation analysis between two matrices.
 
@@ -44,7 +47,7 @@ def canonical_correlation(
 
     The computation proceeds as follows:
 
-    1. Mean-center ``X`` and ``Y``.
+    1. Mean-center ``X`` and ``Y`` (using ``sample_weight`` when supplied).
     2. Compute rank-revealing QR decompositions with column pivoting.
     3. Compute the singular value decomposition of :math:`Q_x^T Q_y`.
     4. Back-solve through the ``R`` factors to obtain canonical coefficients.
@@ -61,6 +64,12 @@ def canonical_correlation(
         First data matrix (e.g. EEG scalp channels).
     Y : ndarray, shape (n_samples, n_features_y)
         Second data matrix (e.g. reference noise channels).
+    sample_weight : ndarray, shape (n_samples,) | None
+        Optional non-negative observation weights. Weighted means, covariance
+        geometry, and canonical-variate normalization are then used.
+    rtol : float | None
+        Optional relative rank threshold applied to the diagonal of each QR
+        factor. ``None`` uses the existing machine-precision threshold.
 
     Returns
     -------
@@ -112,16 +121,49 @@ def canonical_correlation(
             f"got {X.shape[0]} and {Y.shape[0]}"
         )
 
-    Xc = X - X.mean(axis=0, keepdims=True)
-    Yc = Y - Y.mean(axis=0, keepdims=True)
+    if X.ndim != 2 or Y.ndim != 2:
+        raise ValueError("X and Y must both be two-dimensional")
+    if rtol is not None:
+        if not np.isscalar(rtol) or isinstance(rtol, bool):
+            raise TypeError("rtol must be a positive finite number or None")
+        rtol = float(rtol)
+        if not np.isfinite(rtol) or rtol <= 0:
+            raise ValueError("rtol must be a positive finite number or None")
 
-    Qx, Rx, Px = la.qr(Xc, mode="economic", pivoting=True)
-    Qy, Ry, Py = la.qr(Yc, mode="economic", pivoting=True)
+    if sample_weight is None:
+        weights = None
+        Xc = X - X.mean(axis=0, keepdims=True)
+        Yc = Y - Y.mean(axis=0, keepdims=True)
+        X_decomposition = Xc
+        Y_decomposition = Yc
+    else:
+        weights = np.asarray(sample_weight, dtype=np.float64)
+        if weights.shape != (X.shape[0],):
+            raise ValueError(
+                f"sample_weight must have shape ({X.shape[0]},); got {weights.shape}"
+            )
+        if not np.all(np.isfinite(weights)):
+            raise ValueError("sample_weight must contain only finite values")
+        if np.any(weights < 0):
+            raise ValueError("sample_weight must be non-negative")
+        total_weight = weights.sum()
+        if total_weight <= 0:
+            raise ValueError("sample_weight must have a positive sum")
+        Xc = X - (weights @ X / total_weight)[np.newaxis, :]
+        Yc = Y - (weights @ Y / total_weight)[np.newaxis, :]
+        root_weight = np.sqrt(weights)[:, np.newaxis]
+        X_decomposition = Xc * root_weight
+        Y_decomposition = Yc * root_weight
+
+    Qx, Rx, Px = la.qr(X_decomposition, mode="economic", pivoting=True)
+    Qy, Ry, Py = la.qr(Y_decomposition, mode="economic", pivoting=True)
 
     eps = np.finfo(np.float64).eps
 
-    tolx = eps * max(Xc.shape) * (np.abs(np.diag(Rx)).max() if Rx.size else 0.0)
-    toly = eps * max(Yc.shape) * (np.abs(np.diag(Ry)).max() if Ry.size else 0.0)
+    scale_x = np.abs(np.diag(Rx)).max() if Rx.size else 0.0
+    scale_y = np.abs(np.diag(Ry)).max() if Ry.size else 0.0
+    tolx = eps * max(Xc.shape) * scale_x if rtol is None else rtol * scale_x
+    toly = eps * max(Yc.shape) * scale_y if rtol is None else rtol * scale_y
     rx = int(np.sum(np.abs(np.diag(Rx)) > tolx)) if Rx.size else 0
     ry = int(np.sum(np.abs(np.diag(Ry)) > toly)) if Ry.size else 0
 
@@ -154,10 +196,11 @@ def canonical_correlation(
     U = Xc @ A
     V = Yc @ B
 
-    def _unit_var(
-        Z: np.ndarray,
-    ) -> tuple[np.ndarray, np.ndarray]:
-        std = Z.std(axis=0, ddof=1)
+    def _unit_var(Z: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        if weights is None:
+            std = Z.std(axis=0, ddof=1)
+        else:
+            std = np.sqrt((weights @ (Z**2)) / weights.sum())
         std[std == 0] = 1.0
         return Z / std, 1.0 / std
 

--- a/mne_denoise/_covariance.py
+++ b/mne_denoise/_covariance.py
@@ -14,6 +14,59 @@ import numpy as np
 from ._validation import check_chunk_size
 
 
+def _flatten_observations(
+    data: np.ndarray, weights: np.ndarray | None
+) -> tuple[np.ndarray, np.ndarray, bool]:
+    """Return channel-by-observation data and its validated weight measure."""
+    data = np.asarray(data, dtype=float)
+    user_weights = weights is not None
+    if data.ndim == 3:
+        n_channels, n_times, n_epochs = data.shape
+        data = data.reshape(n_channels, -1)
+        if user_weights:
+            weights = np.asarray(weights, dtype=float)
+            if weights.shape == (n_times,):
+                weights = np.repeat(weights, n_epochs)
+            elif weights.shape == (n_times, n_epochs):
+                weights = weights.reshape(-1)
+            elif weights.shape != (n_times * n_epochs,):
+                raise ValueError(
+                    "For 3D data, weights must have shape "
+                    f"({n_times},), ({n_times}, {n_epochs}), or "
+                    f"({n_times * n_epochs},); got {weights.shape}"
+                )
+    if data.ndim != 2:
+        raise ValueError(f"data must be 2D or 3D, got shape {data.shape}")
+
+    if user_weights:
+        weights = np.asarray(weights, dtype=float)
+        if weights.ndim != 1:
+            raise ValueError(
+                "For 2D data, weights must be one-dimensional; "
+                f"got shape {weights.shape}"
+            )
+        if weights.shape[0] != data.shape[1]:
+            raise ValueError(
+                f"Weights length {weights.shape[0]} does not match "
+                f"data samples {data.shape[1]}"
+            )
+        if not np.all(np.isfinite(weights)):
+            raise ValueError("weights must contain only finite values")
+        if np.any(weights < 0):
+            raise ValueError("weights must be non-negative")
+        if weights.sum() <= 0:
+            raise ValueError("Sum of weights must be positive")
+    else:
+        weights = np.ones(data.shape[1])
+    return data, weights, user_weights
+
+
+def compute_mean(data: np.ndarray, *, weights: np.ndarray | None = None) -> np.ndarray:
+    """Compute one channel mean over 2-D or 3-D observations."""
+    data, weights, _ = _flatten_observations(data, weights)
+    return (data @ weights / weights.sum())[:, np.newaxis]
+
+
 def compute_covariance(
     data: np.ndarray,
     *,
@@ -43,9 +96,14 @@ def compute_covariance(
     shrinkage : float, optional
         Shrinkage parameter (0 to 1) for 'shrinkage' method. If None,
         optimal shrinkage is estimated.
-    weights : ndarray, shape (n_times,), optional
-        Sample weights for covariance computation. High weights emphasize time points,
-        zero weights ignore them. Currently only supported for `method='empirical'`.
+    weights : ndarray | None
+        Sample weights for covariance computation. High weights emphasize time
+        points and zero weights ignore them. For three-dimensional data, a
+        one-dimensional ``n_times`` vector is broadcast across epochs, a
+        ``(n_times, n_epochs)`` matrix assigns every observation explicitly,
+        and a flattened vector must follow the C-order observation layout of
+        ``data.reshape(n_channels, -1)``. Currently only supported for
+        ``method='empirical'``.
     assume_centered : bool, default=False
         If True, treat ``data`` as already centered and skip mean subtraction.
     chunk_size : int | None, default=None
@@ -58,41 +116,21 @@ def compute_covariance(
     cov : ndarray, shape (n_channels, n_channels)
         The estimated covariance matrix.
     """
-    data = np.asarray(data, dtype=float)
-    if data.ndim == 3:
-        n_channels, n_times_in, n_epochs = data.shape
-        data = data.reshape(n_channels, -1)
-
-        if weights is not None and weights.shape[0] == n_times_in:
-            # Tile weights across epochs
-            weights = np.tile(weights, n_epochs)
-
-    if data.ndim != 2:
-        raise ValueError(f"data must be 2D or 3D, got shape {data.shape}")
+    data, weights, user_weights = _flatten_observations(data, weights)
     n_channels, n_times = data.shape
 
     chunk_size = check_chunk_size(chunk_size)
     if chunk_size is not None and method != "empirical":
         raise ValueError("chunk_size is only supported for empirical covariance")
 
-    if weights is not None:
-        if data.shape[1] != weights.shape[0]:
-            raise ValueError(
-                f"Weights length {weights.shape[0]} does not match "
-                f"data samples {data.shape[1]}"
-            )
+    if user_weights:
         total_weight = np.sum(weights)
-        if total_weight == 0:
-            raise ValueError("Sum of weights is zero")
-
         if method != "empirical":
             # Currently we only support weighted empirical.
             raise ValueError(
                 f"Weighted covariance not implemented for method '{method}'"
             )
     else:
-        # If no weights are provided, use equal weights; to simplify the implementation
-        weights = np.ones(n_times)
         total_weight = n_times
 
     if assume_centered:

--- a/mne_denoise/_spatial.py
+++ b/mne_denoise/_spatial.py
@@ -54,6 +54,59 @@ def apply_spatial_transform(
     return transformed.reshape((matrix.shape[0], *data.shape[1:]))
 
 
+def fit_mixing_matrix(
+    data: np.ndarray,
+    sources: np.ndarray,
+    *,
+    sample_weight: np.ndarray | None = None,
+) -> np.ndarray:
+    """Fit a least-squares projection from components to channel data.
+
+    Parameters
+    ----------
+    data : ndarray, shape (n_channels, ...)
+        Channel-first target data.
+    sources : ndarray, shape (n_components, ...)
+        Component time courses with the same trailing observation dimensions.
+    sample_weight : ndarray | None
+        Optional weights shaped like the trailing observation dimensions, or
+        flattened in their C-order layout.
+
+    Returns
+    -------
+    mixing : ndarray, shape (n_channels, n_components)
+        Least-squares sensor projection.
+    """
+    data = np.asarray(data, dtype=np.float64)
+    sources = np.asarray(sources, dtype=np.float64)
+    if data.ndim < 2 or sources.ndim != data.ndim:
+        raise ValueError("data and sources must have matching dimensions of at least 2")
+    if data.shape[1:] != sources.shape[1:]:
+        raise ValueError("data and sources must have matching observation dimensions")
+
+    data_flat = data.reshape(data.shape[0], -1)
+    sources_flat = sources.reshape(sources.shape[0], -1)
+    if sample_weight is None:
+        weighted_sources = sources_flat
+    else:
+        weights = np.asarray(sample_weight, dtype=np.float64)
+        if weights.shape == data.shape[1:]:
+            weights = weights.reshape(-1)
+        elif weights.shape != (data_flat.shape[1],):
+            raise ValueError(
+                "sample_weight must match the observation dimensions or have "
+                f"shape ({data_flat.shape[1]},); got {weights.shape}"
+            )
+        if not np.all(np.isfinite(weights)) or np.any(weights < 0):
+            raise ValueError("sample_weight must be finite and non-negative")
+        if weights.sum() <= 0:
+            raise ValueError("sample_weight must have a positive sum")
+        weighted_sources = sources_flat * weights
+    return (data_flat @ weighted_sources.T) @ np.linalg.pinv(
+        sources_flat @ weighted_sources.T, hermitian=True
+    )
+
+
 def epochs_to_continuous(data: np.ndarray) -> np.ndarray:
     """Concatenate epoched channel-first data along time.
 

--- a/mne_denoise/_validation.py
+++ b/mne_denoise/_validation.py
@@ -12,6 +12,15 @@ from numbers import Integral, Real
 import numpy as np
 
 
+def check_positive_integer(value: int, *, name: str) -> int:
+    """Validate a positive integer parameter."""
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise TypeError(f"{name} must be a positive integer")
+    if value < 1:
+        raise ValueError(f"{name} must be a positive integer")
+    return int(value)
+
+
 def check_channel_first_data(
     X: np.ndarray,
     *,

--- a/mne_denoise/bss_cca/core.py
+++ b/mne_denoise/bss_cca/core.py
@@ -50,6 +50,7 @@ from .._spatial import (
     apply_spatial_transform,
     continuous_to_epochs,
     epochs_to_continuous,
+    fit_mixing_matrix,
 )
 from .._validation import (
     check_channel_first_data,
@@ -251,7 +252,7 @@ def _learn_operator(
     training_mean = continuous.mean(axis=1, keepdims=True)
     centered = continuous - training_mean
     sources = unmixing @ centered
-    mixing = (centered @ sources.T) @ np.linalg.pinv(sources @ sources.T)
+    mixing = fit_mixing_matrix(centered, sources)
 
     keep = _select_components(
         correlations, n_remove=n_remove, rho_threshold=rho_threshold

--- a/mne_denoise/dss/__init__.py
+++ b/mne_denoise/dss/__init__.py
@@ -2,7 +2,7 @@
 
 This module contains:
 - Core DSS algorithms (linear and nonlinear)
-- Variants and applications (TSR, SSVEP, Narrowband)
+- Variants and applications (Time-shift DSS, SSVEP, Narrowband)
 
 For ZapLine, see `mne_denoise.zapline`.
 """
@@ -17,6 +17,7 @@ from .denoisers import (
     DCTDenoiser,
     GaussDenoiser,
     KurtosisDenoiser,
+    LagAverageBias,
     LinearDenoiser,
     LineNoiseBias,
     NonlinearDenoiser,
@@ -29,7 +30,6 @@ from .denoisers import (
     SpectrogramBias,
     SpectrogramDenoiser,
     TanhMaskDenoiser,
-    TimeShiftBias,
     WienerMaskDenoiser,
     beta_gauss,
     beta_pow3,
@@ -54,12 +54,13 @@ from .variants.narrowband import narrowband_dss, narrowband_scan
 from .variants.ssvep import ssvep_dss
 
 # Variants (Direct Access)
-from .variants.tsr import smooth_dss, time_shift_dss
+from .variants.tsr import TimeShiftDSS, smooth_dss
 
 __all__ = [
     # Core
     "compute_dss",
     "DSS",
+    "TimeShiftDSS",
     "iterative_dss",
     "iterative_dss_one",
     "IterativeDSS",
@@ -68,7 +69,6 @@ __all__ = [
     "ssvep",
     "narrowband",
     # Variants functions
-    "time_shift_dss",
     "smooth_dss",
     "ssvep_dss",
     "narrowband_scan",
@@ -99,6 +99,6 @@ __all__ = [
     "beta_tanh",
     "beta_pow3",
     "beta_gauss",
-    "TimeShiftBias",
+    "LagAverageBias",
     "SmoothingBias",
 ]

--- a/mne_denoise/dss/denoisers/__init__.py
+++ b/mne_denoise/dss/denoisers/__init__.py
@@ -28,8 +28,8 @@ from .spectral import (
 from .spectrogram import SpectrogramBias, SpectrogramDenoiser
 from .temporal import (
     DCTDenoiser,
+    LagAverageBias,
     SmoothingBias,
-    TimeShiftBias,
 )
 
 __all__ = [
@@ -44,6 +44,7 @@ __all__ = [
     "PeakFilterBias",
     "CombFilterBias",
     "CycleAverageBias",
+    "LagAverageBias",
     # Nonlinear denoisers (paper-faithful)
     "VarianceMaskDenoiser",
     "WienerMaskDenoiser",
@@ -61,7 +62,5 @@ __all__ = [
     "beta_tanh",
     "beta_pow3",
     "beta_gauss",
-    # Deprecated
-    "TimeShiftBias",
     "SmoothingBias",
 ]

--- a/mne_denoise/dss/denoisers/averaging.py
+++ b/mne_denoise/dss/denoisers/averaging.py
@@ -34,7 +34,10 @@ class AverageBias(LinearDenoiser):
         - 'epochs' (default): Average across trials. Input shape: (n_channels, n_times, n_epochs)
         - 'datasets': Average across datasets/subjects. Input shape: (n_datasets, n_channels, n_times)
     weights : array-like, optional
-        Weights for averaging. If None, uniform weighting.
+        Weights for averaging. For ``axis='epochs'``, either one weight per
+        epoch or a ``(n_times, n_epochs)`` observation-weight matrix. For
+        ``axis='datasets'``, one weight per dataset. If None, use uniform
+        weighting.
 
     Examples
     --------
@@ -92,13 +95,36 @@ class AverageBias(LinearDenoiser):
         n_channels, n_times, n_epochs = data.shape
 
         if self.weights is not None:
-            weights = np.asarray(self.weights)
-            if weights.shape[0] != n_epochs:
-                raise ValueError(
-                    f"weights length ({len(weights)}) must match n_epochs ({n_epochs})"
+            weights = np.asarray(self.weights, dtype=float)
+            if not np.all(np.isfinite(weights)) or np.any(weights < 0):
+                raise ValueError("weights must be finite and non-negative")
+            if weights.shape == (n_epochs,):
+                if weights.sum() <= 0:
+                    raise ValueError("weights must have a positive sum")
+                avg = np.tensordot(
+                    data, weights / weights.sum(), axes=(2, 0)
+                )  # (n_ch, n_times)
+            elif weights.shape == (n_times, n_epochs):
+                weight_per_time = weights.sum(axis=1)
+                if not np.any(weight_per_time > 0):
+                    raise ValueError("weights must contain a positive observation")
+                weighted_sum = np.einsum("cte,te->ct", data, weights, optimize=True)
+                avg = np.divide(
+                    weighted_sum,
+                    weight_per_time[np.newaxis, :],
+                    out=np.zeros_like(weighted_sum, dtype=float),
+                    where=weight_per_time[np.newaxis, :] > 0,
                 )
-            weights = weights / weights.sum()
-            avg = np.tensordot(data, weights, axes=(2, 0))  # (n_ch, n_times)
+            else:
+                if weights.ndim == 1:
+                    raise ValueError(
+                        f"weights length ({weights.size}) must match "
+                        f"n_epochs ({n_epochs})"
+                    )
+                raise ValueError(
+                    "weights must have shape "
+                    f"({n_epochs},) or ({n_times}, {n_epochs}); got {weights.shape}"
+                )
         else:
             avg = data.mean(axis=2)
 
@@ -117,11 +143,20 @@ class AverageBias(LinearDenoiser):
         n_datasets, n_channels, n_times = data.shape
 
         if self.weights is not None:
-            weights = np.asarray(self.weights)
-            if weights.shape[0] != n_datasets:
+            weights = np.asarray(self.weights, dtype=float)
+            if weights.shape != (n_datasets,):
+                if weights.ndim == 1:
+                    raise ValueError(
+                        f"weights length ({weights.size}) must match "
+                        f"n_datasets ({n_datasets})"
+                    )
                 raise ValueError(
-                    f"weights length ({len(weights)}) must match n_datasets ({n_datasets})"
+                    f"weights must have shape ({n_datasets},); got {weights.shape}"
                 )
+            if not np.all(np.isfinite(weights)) or np.any(weights < 0):
+                raise ValueError("weights must be finite and non-negative")
+            if weights.sum() <= 0:
+                raise ValueError("weights must have a positive sum")
             weights = weights / weights.sum()
             avg = np.tensordot(weights, data, axes=(0, 0))  # (n_ch, n_times)
         else:

--- a/mne_denoise/dss/denoisers/temporal.py
+++ b/mne_denoise/dss/denoisers/temporal.py
@@ -1,6 +1,6 @@
 """Temporal bias functions for DSS.
 
-Implements time-shift and smoothing biases for extracting temporally
+Implements lag-averaging and smoothing biases for extracting temporally
 extended structure (slow waves, autocorrelated signals).
 
 Authors: Sina Esmaeili (sina.esmaeili@umontreal.ca)
@@ -8,11 +8,9 @@ Authors: Sina Esmaeili (sina.esmaeili@umontreal.ca)
 
 References
 ----------
-.. [1] de Cheveigné, A. (2010). Time-shift denoising source separation.
-       Journal of Neuroscience Methods, 189(1), 113-120.
-.. [2] de Cheveigné, A. & Simon, J.Z. (2008). Denoising based on spatial filtering.
+.. [1] de Cheveigné, A. & Simon, J.Z. (2008). Denoising based on spatial filtering.
        Journal of Neuroscience Methods, 171(2), 331-339.
-.. [3] de Cheveigné, A. (2020). ZapLine: A simple and effective method to remove
+.. [2] de Cheveigné, A. (2020). ZapLine: A simple and effective method to remove
        power line artifacts. NeuroImage, 207, 116356. (Period-matched
        smooth/residual decomposition: spatially clean only the residual branch
        and add the smooth branch back.)
@@ -20,31 +18,35 @@ References
 
 from __future__ import annotations
 
+from numbers import Integral
+
 import numpy as np
 
 from .base import LinearDenoiser, NonlinearDenoiser
 
 
-class TimeShiftBias(LinearDenoiser):
-    """Time-shift bias for extracting autocorrelated signals.
+class LagAverageBias(LinearDenoiser):
+    """Lag-averaging bias for emphasizing temporally smooth signals.
 
     Creates a bias by averaging time-shifted versions of the data,
-    emphasizing signals that are predictable across time lags.
+    emphasizing signals that remain similar across the selected lags. This is
+    a lightweight package bias for ordinary sensor-space DSS; it is not the
+    lag-augmented :class:`~mne_denoise.dss.TimeShiftDSS` estimator.
 
     Parameters
     ----------
-    shifts : int or array-like
-        If int, use lags from 1 to shifts.
+    lags : int or array-like
+        If int, use lags from 1 through ``lags``.
         If array, use specified lag values in samples.
         Default 10.
-    method : str
-        Method for constructing bias:
-        - 'autocorrelation': Average of shifted versions (default)
-        - 'prediction': Weighted average (closer lags weighted more)
+    weighting : {'uniform', 'inverse_lag'}
+        Weight every lag equally or weight it by inverse absolute lag.
+        Neither option estimates an autocorrelation function or fits prediction
+        coefficients.
 
     Examples
     --------
-    >>> bias = TimeShiftBias(shifts=[1, 2, 5, 10], method="prediction")
+    >>> bias = LagAverageBias(lags=[1, 2, 5, 10], weighting="inverse_lag")
     >>> biased_data = bias.apply(data)
 
     See Also
@@ -54,17 +56,32 @@ class TimeShiftBias(LinearDenoiser):
 
     def __init__(
         self,
-        shifts: int | np.ndarray = 10,
-        method: str = "autocorrelation",
+        lags: int | np.ndarray = 10,
+        weighting: str = "uniform",
     ) -> None:
-        self.shifts = shifts
-        self.method = method
+        self.lags = lags
+        self.weighting = weighting
 
-        # Resolve shifts to array
-        if isinstance(shifts, int):
-            self._shift_array = np.arange(1, shifts + 1)
-        else:
-            self._shift_array = np.asarray(shifts)
+    def _resolve_lags(self) -> np.ndarray:
+        """Return a validated, unique lag vector."""
+        if isinstance(self.lags, bool):
+            raise TypeError("lags must be a positive integer or integer array")
+        if isinstance(self.lags, Integral):
+            if self.lags < 1:
+                raise ValueError("lags must be positive")
+            return np.arange(1, int(self.lags) + 1)
+        values = np.asarray(self.lags, dtype=object)
+        if values.ndim != 1 or values.size == 0:
+            raise ValueError("lags must be a non-empty one-dimensional array")
+        if any(
+            isinstance(value, bool) or not isinstance(value, Integral)
+            for value in values.tolist()
+        ):
+            raise TypeError("lags must contain only integers")
+        resolved = np.unique(values.astype(int))
+        if not np.any(resolved != 0):
+            raise ValueError("lags must contain at least one nonzero lag")
+        return resolved
 
     def apply(self, data: np.ndarray) -> np.ndarray:
         """Apply time-shift bias.
@@ -79,31 +96,29 @@ class TimeShiftBias(LinearDenoiser):
         biased : ndarray, same shape as input
             Time-shifted averaged data.
         """
-        # Handle 3D data
-        orig_shape = data.shape
-        if data.ndim == 3:
-            n_ch, n_times, n_epochs = data.shape
-            data_2d = data.reshape(n_ch, -1)
+        data = np.asarray(data, dtype=np.float64)
+        if data.ndim not in (2, 3):
+            raise ValueError("data must be 2D or 3D")
+        self._lag_array = self._resolve_lags()
+        if self.weighting == "uniform":
+            operation = self._equal_lag_average
+        elif self.weighting == "inverse_lag":
+            operation = self._weighted_lag_average
         else:
-            data_2d = data
+            raise ValueError("weighting must be 'uniform' or 'inverse_lag'")
 
-        if self.method == "autocorrelation":
-            biased_2d = self._autocorrelation_bias(data_2d)
-        elif self.method == "prediction":
-            biased_2d = self._prediction_bias(data_2d)
-        else:
-            raise ValueError(f"Unknown method: {self.method}")
+        if data.ndim == 2:
+            return operation(data)
+        return np.stack(
+            [operation(data[:, :, epoch]) for epoch in range(data.shape[2])],
+            axis=2,
+        )
 
-        # Restore shape
-        if data.ndim == 3:
-            return biased_2d.reshape(orig_shape)
-        return biased_2d
-
-    def _autocorrelation_bias(self, data: np.ndarray) -> np.ndarray:
-        """Average of time-shifted versions."""
+    def _equal_lag_average(self, data: np.ndarray) -> np.ndarray:
+        """Average time-shifted versions with equal weights."""
         n_channels, n_samples = data.shape
-        shifts = self._shift_array
-        max_shift = np.max(np.abs(shifts))
+        lags = self._lag_array
+        max_shift = np.max(np.abs(lags))
 
         if max_shift >= n_samples // 2:
             raise ValueError(
@@ -115,22 +130,22 @@ class TimeShiftBias(LinearDenoiser):
         valid_length = valid_end - valid_start
 
         accumulated = np.zeros((n_channels, valid_length))
-        for shift in shifts:
+        for shift in lags:
             shifted = data[:, valid_start + shift : valid_end + shift]
             accumulated += shifted
 
-        biased = accumulated / len(shifts)
+        biased = accumulated / len(lags)
 
         # Pad to original length
         biased_full = np.zeros_like(data)
         biased_full[:, valid_start:valid_end] = biased
         return biased_full
 
-    def _prediction_bias(self, data: np.ndarray) -> np.ndarray:
-        """Weighted average (closer lags weighted more)."""
+    def _weighted_lag_average(self, data: np.ndarray) -> np.ndarray:
+        """Average time-shifted versions with inverse-lag weights."""
         n_channels, n_samples = data.shape
-        shifts = self._shift_array
-        max_shift = np.max(np.abs(shifts))
+        lags = self._lag_array
+        max_shift = np.max(np.abs(lags))
 
         valid_start = max_shift
         valid_end = n_samples - max_shift
@@ -139,7 +154,7 @@ class TimeShiftBias(LinearDenoiser):
         accumulated = np.zeros((n_channels, valid_length))
         total_weight = 0
 
-        for shift in shifts:
+        for shift in lags:
             weight = 1.0 / max(abs(shift), 1)
             shifted = data[:, valid_start + shift : valid_end + shift]
             accumulated += weight * shifted
@@ -158,7 +173,7 @@ class SmoothingBias(LinearDenoiser):
     Uses a boxcar moving average filter to smooth the data. When used to split
     the signal into a smooth branch and a residual (``data - smooth``), fitting
     DSS on the residual and adding the smooth branch back follows ZapLine's
-    period-matched decomposition (de Cheveigné, 2020 [3]_): with
+    period-matched decomposition (de Cheveigné, 2020): with
     ``window = round(sfreq / f_line)`` the smoother has zeros at ``f_line`` and
     its harmonics, so the residual concentrates the narrowband artifact.
 

--- a/mne_denoise/dss/linear.py
+++ b/mne_denoise/dss/linear.py
@@ -30,7 +30,7 @@ try:
 except ImportError:
     mne = None
 
-from .._covariance import compute_covariance
+from .._covariance import compute_covariance, compute_mean
 from .._logging import set_log_level_from_verbose
 from .._spatial import (
     apply_spatial_transform,
@@ -380,6 +380,10 @@ class DSS(BaseEstimator, TransformerMixin):
         Ignored when ``whiten=False``.
     verbose : bool | str | int | None, default=None
         Control logging verbosity.
+    center : bool, default=True
+        If True, subtract one global channel mean fitted on the training data
+        and reuse it for every transform. If False, use uncentered second
+        moments. Transform batches are never centered from their own data.
 
     Attributes
     ----------
@@ -389,6 +393,9 @@ class DSS(BaseEstimator, TransformerMixin):
         The spatial patterns (mixing matrix).
     eigenvalues_ : array, shape (n_components,)
         The power of each component in the biased data (bias score).
+    mean_ : array, shape (n_channels, 1)
+        Global training mean reused by :meth:`transform`, or zeros when
+        ``center=False``.
     n_selected_ : int | None
         Number of significant components detected by automatic selection.
         Only set when ``n_select`` is not ``None``. Use this to determine
@@ -447,6 +454,7 @@ class DSS(BaseEstimator, TransformerMixin):
         whiten: bool = False,
         noise_cov=None,
         verbose: bool | str | int | None = None,
+        center: bool = True,
     ) -> None:
         self.n_components = n_components
         self.bias = bias
@@ -457,6 +465,7 @@ class DSS(BaseEstimator, TransformerMixin):
         self.rank = rank
         self.reg = reg
         self.normalize_input = normalize_input
+        self.center = center
         self.cov_method = cov_method
         self.cov_kws = cov_kws
         self.smooth = smooth
@@ -478,6 +487,7 @@ class DSS(BaseEstimator, TransformerMixin):
         self.eigenvalues_: np.ndarray | None = None
         self.explained_variance_: np.ndarray | None = None
         self.channel_norms_: np.ndarray | None = None
+        self.mean_: np.ndarray | None = None
         self.n_selected_: np.ndarray | None = None
         self.segment_results_: list | None = None
         self._whitener_: np.ndarray | None = None
@@ -517,6 +527,8 @@ class DSS(BaseEstimator, TransformerMixin):
         set_log_level_from_verbose(self.verbose)
         self._mne_ch_names_ = None
         self._validate_component_action()
+        if not isinstance(self.center, bool):
+            raise TypeError("center must be a bool")
         if self.adaptive:
             logger.info(
                 "DSS(adaptive=True).fit() computes a single global fit. "
@@ -736,6 +748,15 @@ class DSS(BaseEstimator, TransformerMixin):
         else:
             return self.bias(data)
 
+    def _fit_mean(self, data: np.ndarray, weights: np.ndarray | None = None) -> None:
+        """Store the channel origin used by every subsequent transform."""
+        data = np.asarray(data, dtype=np.float64)
+        self.mean_ = (
+            compute_mean(data, weights=weights)
+            if self.center
+            else np.zeros((data.shape[0], 1), dtype=np.float64)
+        )
+
     def _fit_mne(
         self,
         inst: BaseRaw | BaseEpochs | Evoked,
@@ -763,11 +784,13 @@ class DSS(BaseEstimator, TransformerMixin):
         self.info_ = inst.info
         self._mne_info = self.info_
 
-        if weights is not None:
-            # Weighted MNE input uses the canonical channel-first NumPy path.
+        if weights is not None or not self.center or isinstance(inst, Evoked):
+            # Weighted or explicitly uncentered MNE input uses the canonical
+            # channel-first NumPy path.
             self._fit_numpy(data, weights=weights)
             return
 
+        self._fit_mean(data)
         biased_data = self._apply_bias(data)
 
         if isinstance(inst, BaseEpochs):
@@ -808,10 +831,12 @@ class DSS(BaseEstimator, TransformerMixin):
 
     def _fit_numpy(self, X: np.ndarray, weights: np.ndarray | None = None) -> None:
         """Fit using numpy arrays."""
+        self._fit_mean(X, weights)
         biased_X = self._apply_bias(X)
 
         method = self.cov_method
         kws = self.cov_kws.copy() if self.cov_kws else {}
+        kws["assume_centered"] = not self.center
 
         baseline_cov = compute_covariance(X, method=method, weights=weights, **kws)
         biased_cov = compute_covariance(biased_X, method=method, weights=weights, **kws)
@@ -850,6 +875,7 @@ class DSS(BaseEstimator, TransformerMixin):
         # The NumPy covariance helper does not accept MNE-only options.
         for key in ("rank", "verbose", "tstep"):
             kws.pop(key, None)
+        kws["assume_centered"] = not self.center
 
         data, _, _, orig_inst, picks, ch_names = extract_data_from_mne(
             X,
@@ -867,6 +893,7 @@ class DSS(BaseEstimator, TransformerMixin):
             self.info_ = None
         self._mne_info = self.info_
 
+        self._fit_mean(data, weights)
         data_w = self._prewhiten_sensor_data(
             data,
             info=self.info_,
@@ -986,10 +1013,12 @@ class DSS(BaseEstimator, TransformerMixin):
             data_2d = data_for_dss
             full_data_2d = data
 
-        # Center using mean on data_2d
-        # DSS implies zero-mean assumption for correct projection
-        mean_ = data_2d.mean(axis=1, keepdims=True)
-        data_centered = data_2d - mean_
+        # Apply the centering measure fitted with the DSS filters. Recomputing
+        # this mean from each transform batch would make a learned transform
+        # depend on unrelated observations supplied alongside it.
+        if self.mean_ is None:
+            raise RuntimeError("DSS fitted centering state is unavailable")
+        data_centered = data_2d - self.mean_
 
         sources = self.filters_ @ data_centered
 
@@ -1011,7 +1040,7 @@ class DSS(BaseEstimator, TransformerMixin):
         if action == "subtract":
             rec = full_data_2d - selected
         else:
-            rec = selected + mean_
+            rec = selected + self.mean_
             if data_smooth is not None:
                 smooth_2d = (
                     data_smooth.reshape(data_smooth.shape[0], -1)

--- a/mne_denoise/dss/variants/__init__.py
+++ b/mne_denoise/dss/variants/__init__.py
@@ -1,17 +1,17 @@
 """DSS Variants and Applications.
 
 Contains specialized implementations of DSS for specific tasks:
-- TSR: Time-Shift DSS for temporal structure
+- Time-shift DSS: lag-augmented repeated-trial DSS and temporal smoothing
 - SSVEP: SSVEP enhancement using comb filters
 - Narrowband: Frequency scanning and band-specific extraction
 """
 
 from .narrowband import narrowband_dss, narrowband_scan
 from .ssvep import ssvep_dss
-from .tsr import smooth_dss, time_shift_dss
+from .tsr import TimeShiftDSS, smooth_dss
 
 __all__ = [
-    "time_shift_dss",
+    "TimeShiftDSS",
     "smooth_dss",
     "ssvep_dss",
     "narrowband_scan",

--- a/mne_denoise/dss/variants/tsr.py
+++ b/mne_denoise/dss/variants/tsr.py
@@ -1,70 +1,519 @@
-"""Time-Shift DSS (TSR) variant.
+"""Temporal DSS variants.
 
-Convenience wrapper for extracting temporally extended structure
-(autocorrelated signals, slow waves, DC shifts) [1]_.
-
-Authors: Sina Esmaeili (sina.esmaeili@umontreal.ca)
-         Hamza Abdelhedi (hamza.abdelhedi@umontreal.ca)
-
-References
-----------
-.. [1] de Cheveigné, A. (2010). Time-shift denoising source separation.
-       Journal of Neuroscience Methods, 189(1), 113-120.
+Time-shift DSS augments every sensor with delayed copies, then composes the
+package's :class:`DSS` estimator with :class:`AverageBias` across trials. The
+initial public contract implements the repeated-trial contrast evaluated by
+de Cheveigne (2010); arbitrary bias operators are intentionally outside that
+claim. :func:`smooth_dss` remains the lightweight ordinary-DSS smoothing
+configuration.
 """
 
 from __future__ import annotations
 
-import numpy as np
+import warnings
+from collections.abc import Sequence
+from numbers import Integral, Real
+from typing import Any
 
-from ..denoisers.temporal import SmoothingBias, TimeShiftBias
+import numpy as np
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.utils.validation import check_is_fitted
+
+try:
+    from mne.epochs import BaseEpochs
+except ImportError:  # pragma: no cover - MNE is a required dependency
+    BaseEpochs = ()
+
+from ..._cca import canonical_correlation
+from ..._logging import set_log_level_from_verbose
+from ..._spatial import fit_mixing_matrix
+from ..._validation import check_positive_integer, resolve_sfreq
+from ...utils import extract_data_from_mne, reconstruct_mne_object
+from ..denoisers import AverageBias, SmoothingBias
 from ..linear import DSS
 
+_ACTIONS = frozenset({"extract", "retain", "subtract"})
+_DISTORTION_CONTROLS = frozenset({None, "cca"})
 
-def time_shift_dss(
-    shifts: int | np.ndarray = 10,
+
+def _resolve_lags(
     *,
-    method: str = "autocorrelation",
-    n_components: int | None = None,
-    **dss_kws,
-) -> DSS:
-    """Create a DSS configured for temporal predictability.
+    lag_samples: Sequence[int] | None,
+    lag_times: Sequence[float] | None,
+    sfreq: float | None,
+) -> tuple[tuple[int, ...], tuple[float, ...] | None, float | None]:
+    """Resolve exactly one physical or sample lag declaration."""
 
-    Returns a pre-configured DSS object that extracts components with
-    high autocorrelation (temporally smooth or predictable signals).
+    def _as_samples(values: Sequence[int]) -> tuple[int, ...]:
+        if isinstance(values, str | bytes):
+            raise TypeError(
+                "lag_samples must be a one-dimensional sequence of integers"
+            )
+        array = np.asarray(values, dtype=object)
+        if array.ndim != 1 or array.size == 0:
+            raise ValueError("lag_samples must be a non-empty one-dimensional sequence")
+        samples = []
+        for value in array.tolist():
+            if isinstance(value, bool) or not isinstance(value, Integral):
+                raise TypeError("lag_samples must contain only integers")
+            samples.append(int(value))
+        resolved = tuple(sorted(set(samples)))
+        if len(resolved) < 2 or 0 not in resolved:
+            raise ValueError(
+                "lag_samples must contain zero and at least one nonzero lag"
+            )
+        return resolved
+
+    if (lag_samples is None) == (lag_times is None):
+        raise ValueError("Provide exactly one of lag_samples or lag_times")
+    if lag_samples is not None:
+        samples = _as_samples(lag_samples)
+        times = (
+            tuple(sample / sfreq for sample in samples) if sfreq is not None else None
+        )
+        return samples, times, sfreq
+
+    sfreq = resolve_sfreq(sfreq, None, context="lag_times")
+    if isinstance(lag_times, str | bytes):
+        raise TypeError("lag_times must be a one-dimensional sequence")
+    raw_values = np.asarray(lag_times, dtype=object)
+    if any(isinstance(value, bool) for value in raw_values.reshape(-1).tolist()):
+        raise TypeError("lag_times must not contain booleans")
+    values = np.asarray(lag_times, dtype=float)
+    if values.ndim != 1 or values.size == 0 or not np.all(np.isfinite(values)):
+        raise ValueError(
+            "lag_times must be a non-empty finite one-dimensional sequence"
+        )
+    sample_values = values * sfreq
+    rounded = np.rint(sample_values)
+    if not np.allclose(sample_values, rounded, rtol=0.0, atol=1e-10):
+        raise ValueError("Every lag_time must fall exactly on the sampling grid")
+    samples = _as_samples([int(value) for value in rounded])
+    return samples, tuple(sample / sfreq for sample in samples), sfreq
+
+
+def _validate_epoched_array(data: Any) -> np.ndarray:
+    """Return finite float data in channel-by-time-by-epoch orientation."""
+    data = np.asarray(data, dtype=np.float64)
+    if data.ndim != 3:
+        raise ValueError(
+            "TimeShiftDSS requires epoched data shaped (n_channels, n_times, n_epochs)"
+        )
+    if min(data.shape) < 1 or data.shape[1] < 2:
+        raise ValueError("TimeShiftDSS input dimensions must be non-empty")
+    if data.shape[2] < 2:
+        raise ValueError("TimeShiftDSS requires at least two repeated epochs")
+    if not np.all(np.isfinite(data)):
+        raise ValueError("TimeShiftDSS input must contain only finite values")
+    return data
+
+
+def _lag_augment(
+    data: np.ndarray, lags: tuple[int, ...]
+) -> tuple[np.ndarray, int, int]:
+    """Stack lag-major sensor blocks without wrapping or joining epochs."""
+    start = max(lags)
+    stop = data.shape[1] + min(lags)
+    if stop - start < 2:
+        raise ValueError(
+            "The lag span leaves fewer than two common time samples per epoch"
+        )
+    blocks = [data[:, start - lag : stop - lag, :] for lag in lags]
+    return np.concatenate(blocks, axis=0), start, stop
+
+
+def _observation_weights(
+    weights: np.ndarray | None,
+    *,
+    n_times: int,
+    n_epochs: int,
+    lags: tuple[int, ...],
+    start: int,
+    stop: int,
+) -> np.ndarray:
+    """Validate weights and dilate zeros through every lagged observation."""
+    if weights is None:
+        return np.ones((stop - start, n_epochs), dtype=np.float64)
+
+    base = np.asarray(weights, dtype=np.float64)
+    if base.shape == (n_times,):
+        base = np.broadcast_to(base[:, np.newaxis], (n_times, n_epochs)).copy()
+    elif base.shape != (n_times, n_epochs):
+        raise ValueError(
+            "sample_weight must have shape "
+            f"({n_times},) or ({n_times}, {n_epochs}); got {base.shape}"
+        )
+    if not np.all(np.isfinite(base)):
+        raise ValueError("sample_weight must contain only finite values")
+    if np.any(base < 0):
+        raise ValueError("sample_weight must be non-negative")
+
+    shifted = [base[start - lag : stop - lag, :] for lag in lags]
+    valid = np.minimum.reduce(shifted)
+    if not np.any(valid > 0):
+        raise ValueError("sample_weight leaves no positive-weight lag observations")
+    return valid
+
+
+class TimeShiftDSS(BaseEstimator, TransformerMixin):
+    """Trial-average DSS in a lag-augmented sensor space.
 
     Parameters
     ----------
-    shifts : int or array-like
-        If int, use lags from 1 to shifts.
-        If array, use specified lag values in samples.
-        Default 10.
-    method : str
-        Method for constructing bias:
-        - 'autocorrelation': Average of shifted versions (default)
-        - 'prediction': Weighted average (closer lags weighted more)
-    n_components : int, optional
-        Number of DSS components to keep. If None, keep all.
-    **dss_kws
-        Additional keyword arguments passed to `DSS`.
+    lag_samples : sequence of int | None
+        Explicit lag grid in samples. It must contain zero and at least one
+        nonzero lag. Positive lags contribute ``X(t - lag)``.
+    lag_times : sequence of float | None
+        Explicit lag grid in seconds. Every value must lie on the sampling
+        grid. Exactly one lag representation must be provided.
+    sfreq : float | None
+        Sampling frequency for array data when ``lag_times`` is used. MNE
+        metadata is authoritative and must agree with a supplied value.
+    n_components : int
+        Number of lag-space DSS components to fit. Selection is explicit;
+        there is no in-sample automatic selector.
+    rank : int
+        Explicit whitening rank in the augmented feature space.
+    n_select : int | None
+        Size of the leading component subspace used by :meth:`score` and by
+        sensor-space ``retain`` or ``subtract``. It is required for those
+        operations; extraction itself can leave it unset.
+    component_action : {'extract', 'retain', 'subtract'}
+        Component extraction or sensor-space operation. Sensor operations
+        preserve input shape and leave samples outside the common lag support
+        unchanged.
+    center : bool
+        If ``False`` (default), use source-aligned uncentered second moments.
+        If ``True``, fit one weighted augmented-feature mean and reuse it for
+        every transform. Epoch-wise and transform-batch centering are never
+        performed.
+    distortion_control : {None, 'cca'}
+        Optional paper step 7. ``'cca'`` rotates the fitted reproducible
+        subspace to the single variate most correlated with undelayed training
+        data. It returns one component and requires ``n_select=1`` for sensor
+        operations.
+    reg : float
+        Relative numerical rank tolerance used by DSS and optional CCA.
+    verbose : bool | str | int | None
+        Logging verbosity.
 
-    Returns
-    -------
-    dss : DSS
-        A DSS object configured with a TimeShiftBias.
+    Notes
+    -----
+    Array input is ``(n_channels, n_times, n_epochs)``. MNE Epochs input is
+    accepted natively. Continuous and Evoked inputs are intentionally rejected
+    by this initial repeated-trial implementation.
 
-    Examples
-    --------
-    >>> # Extract temporally predictable components
-    >>> dss = time_shift_dss(shifts=20)
-    >>> dss.fit(data)
-    >>> slow_sources = dss.transform(data)
+    Lag augmentation is the TSDSS-specific layer. The fitted decomposition is
+    available as ``dss_`` and is an ordinary :class:`DSS` configured with
+    ``AverageBias(axis="epochs")``.
 
-    >>> # Use specific lags
-    >>> dss = time_shift_dss(shifts=np.array([1, 2, 5, 10, 20]))
-    >>> dss.fit(data)
+    Component interpretation and parameter choice require held-out and
+    surrogate validation.
     """
-    bias = TimeShiftBias(shifts=shifts, method=method)
-    return DSS(bias=bias, n_components=n_components, **dss_kws)
+
+    def __init__(
+        self,
+        *,
+        lag_samples: Sequence[int] | None = None,
+        lag_times: Sequence[float] | None = None,
+        sfreq: float | None = None,
+        n_components: int,
+        rank: int,
+        n_select: int | None = None,
+        component_action: str = "extract",
+        center: bool = False,
+        distortion_control: str | None = None,
+        reg: float = 1e-9,
+        verbose: bool | str | int | None = None,
+    ) -> None:
+        self.lag_samples = lag_samples
+        self.lag_times = lag_times
+        self.sfreq = sfreq
+        self.n_components = n_components
+        self.rank = rank
+        self.n_select = n_select
+        self.component_action = component_action
+        self.center = center
+        self.distortion_control = distortion_control
+        self.reg = reg
+        self.verbose = verbose
+
+    def _validate_parameters(self) -> None:
+        """Validate constructor state without mutating it."""
+        check_positive_integer(self.n_components, name="n_components")
+        check_positive_integer(self.rank, name="rank")
+        if self.n_select is not None:
+            check_positive_integer(self.n_select, name="n_select")
+        if self.component_action not in _ACTIONS:
+            raise ValueError(f"component_action must be one of {sorted(_ACTIONS)}")
+        if self.component_action != "extract" and self.n_select is None:
+            raise ValueError("n_select is required for retain and subtract actions")
+        if not isinstance(self.center, bool):
+            raise TypeError("center must be a bool")
+        if self.distortion_control not in _DISTORTION_CONTROLS:
+            raise ValueError("distortion_control must be None or 'cca'")
+        if self.distortion_control == "cca" and self.n_select not in (None, 1):
+            raise ValueError("CCA distortion control supports only n_select=1")
+        if isinstance(self.reg, bool) or not isinstance(self.reg, Real):
+            raise TypeError("reg must be a positive finite real number")
+        if not np.isfinite(self.reg) or self.reg <= 0:
+            raise ValueError("reg must be a positive finite real number")
+
+    def _prepare_epochs(
+        self,
+        X: BaseEpochs | np.ndarray,
+        *,
+        fitting: bool,
+    ) -> tuple[np.ndarray, float | None, str, Any, np.ndarray | None]:
+        """Use shared extraction while enforcing the fitted epoch contract."""
+        is_mne = isinstance(X, BaseEpochs)
+        if not is_mne and not isinstance(X, np.ndarray):
+            raise TypeError("TimeShiftDSS supports MNE Epochs or NumPy arrays")
+        if not fitting and is_mne != self._fit_was_mne_:
+            raise TypeError("Transform input must use the container family used in fit")
+        data, data_sfreq, mne_type, orig, picks, ch_names = extract_data_from_mne(
+            X,
+            ch_names=None if fitting else self._mne_ch_names_,
+            channel_first_epochs=True,
+            exclude_bads=fitting,
+        )
+        data = _validate_epoched_array(data)
+        if fitting:
+            self._fit_was_mne_ = is_mne
+            self._mne_ch_names_ = ch_names
+            if orig is not None:
+                fitted = orig.copy()
+                if picks is not None:
+                    fitted.pick(picks)
+                self.info_ = fitted.info
+            else:
+                self.info_ = None
+        else:
+            if self.sfreq_ is not None and data_sfreq is not None:
+                resolve_sfreq(self.sfreq_, data_sfreq)
+            if data.shape[0] != self.n_features_in_:
+                raise ValueError(
+                    f"X has {data.shape[0]} channels; fitted data had "
+                    f"{self.n_features_in_}"
+                )
+        return data, data_sfreq, mne_type, orig, picks
+
+    def fit(
+        self,
+        X: BaseEpochs | np.ndarray,
+        y: None = None,
+        *,
+        sample_weight: np.ndarray | None = None,
+    ) -> TimeShiftDSS:
+        """Fit lag-augmented repeated-trial DSS filters."""
+        del y
+        set_log_level_from_verbose(self.verbose)
+        self._validate_parameters()
+        data, data_sfreq, _, _, _ = self._prepare_epochs(X, fitting=True)
+        effective_sfreq = resolve_sfreq(
+            self.sfreq,
+            data_sfreq,
+            context="lag_times",
+            required=self.lag_times is not None,
+        )
+        lags, lag_times, effective_sfreq = _resolve_lags(
+            lag_samples=self.lag_samples,
+            lag_times=self.lag_times,
+            sfreq=effective_sfreq,
+        )
+        augmented, start, stop = _lag_augment(data, lags)
+        weights = _observation_weights(
+            sample_weight,
+            n_times=data.shape[1],
+            n_epochs=data.shape[2],
+            lags=lags,
+            start=start,
+            stop=stop,
+        )
+        n_features = augmented.shape[0]
+        rank = check_positive_integer(self.rank, name="rank")
+        n_components = check_positive_integer(self.n_components, name="n_components")
+        if rank > n_features:
+            raise ValueError(
+                f"rank={rank} exceeds {n_features} augmented sensor-lag features"
+            )
+        if n_components > rank:
+            raise ValueError("n_components cannot exceed rank")
+        if self.n_select is not None and self.n_select > n_components:
+            raise ValueError("n_select cannot exceed n_components")
+
+        weight_flat = weights.reshape(-1)
+        self.dss_ = DSS(
+            bias=AverageBias(axis="epochs", weights=weights),
+            n_components=n_components,
+            rank=rank,
+            reg=float(self.reg),
+            normalize_input=False,
+            center=self.center,
+            cov_method="empirical",
+            component_action="extract",
+            verbose=self.verbose,
+        )
+        self.dss_.fit(augmented, weights=weights)
+        filters = self.dss_.filters_
+        eigenvalues = self.dss_.eigenvalues_
+        if filters.shape[0] < n_components:
+            raise ValueError(
+                f"n_components={n_components} exceeds the fitted numerical "
+                f"whitening rank ({filters.shape[0]})"
+            )
+        feature_mean = self.dss_.mean_
+        sources = self.dss_.transform(augmented)
+        zero_index = lags.index(0)
+        sensor_mean = feature_mean[
+            zero_index * data.shape[0] : (zero_index + 1) * data.shape[0]
+        ]
+
+        self.cca_correlations_ = None
+        self.cca_rotation_ = None
+        self.cca_source_mean_ = None
+        if self.distortion_control == "cca":
+            source_2d = sources.reshape(sources.shape[0], -1)
+            sensor_2d = data[:, start:stop, :].reshape(data.shape[0], -1)
+            cca_source_mean = (source_2d @ weight_flat / weight_flat.sum())[
+                :, np.newaxis
+            ]
+            cca_sensor_mean = (sensor_2d @ weight_flat / weight_flat.sum())[
+                :, np.newaxis
+            ]
+            source_coefficients, _, correlations, _, _ = canonical_correlation(
+                source_2d.T,
+                sensor_2d.T,
+                sample_weight=weight_flat,
+                rtol=float(self.reg),
+            )
+            if correlations.size == 0:
+                raise ValueError("CCA input has no variance above the rank threshold")
+            rotation = source_coefficients[:, :1].T
+            canonical = rotation @ (source_2d - cca_source_mean)
+            canonical = canonical.reshape((1, *sources.shape[1:]))
+            patterns = fit_mixing_matrix(
+                data[:, start:stop, :] - cca_sensor_mean.reshape(data.shape[0], 1, 1),
+                canonical,
+                sample_weight=weights,
+            )
+            self.cca_rotation_ = rotation
+            self.cca_source_mean_ = cca_source_mean
+            self.cca_correlations_ = correlations
+            sensor_mean = cca_sensor_mean
+        else:
+            sensors = data[:, start:stop, :] - sensor_mean.reshape(data.shape[0], 1, 1)
+            patterns = fit_mixing_matrix(sensors, sources, sample_weight=weights)
+
+        effective_observations = weight_flat.sum() ** 2 / np.dot(
+            weight_flat, weight_flat
+        )
+        if n_features / effective_observations >= 0.5:
+            warnings.warn(
+                "The augmented feature count approaches the Kish effective "
+                "observation count; TimeShiftDSS is at high risk of overfitting. "
+                "Use held-out and surrogate validation.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+        self.filters_ = (
+            filters if self.cca_rotation_ is None else self.cca_rotation_ @ filters
+        )
+        self.patterns_ = patterns
+        self.eigenvalues_ = eigenvalues
+        self.feature_mean_ = feature_mean
+        self.sensor_mean_ = sensor_mean
+        self.lag_samples_ = lags
+        self.lag_times_ = lag_times
+        self.sfreq_ = effective_sfreq
+        self.n_features_in_ = data.shape[0]
+        self.n_augmented_features_ = n_features
+        self.positive_weight_observations_ = int(np.count_nonzero(weight_flat > 0))
+        self.effective_observations_ = float(effective_observations)
+        self.valid_slice_ = slice(start, stop)
+        return self
+
+    def _sources(self, data: np.ndarray) -> tuple[np.ndarray, int, int]:
+        """Apply the frozen lag-space transform."""
+        augmented, start, stop = _lag_augment(data, self.lag_samples_)
+        sources = self.dss_.transform(augmented)
+        sources_2d = sources.reshape(sources.shape[0], -1)
+        if self.cca_rotation_ is not None:
+            sources_2d = self.cca_rotation_ @ (sources_2d - self.cca_source_mean_)
+        sources = sources_2d.reshape((sources_2d.shape[0], stop - start, data.shape[2]))
+        return sources, start, stop
+
+    def score(
+        self,
+        X: BaseEpochs | np.ndarray,
+        y: None = None,
+        *,
+        sample_weight: np.ndarray | None = None,
+    ) -> float:
+        """Score the leading fitted subspace on held-out repeated trials.
+
+        The score is the trial-average power divided by total power, summed
+        over the first ``n_select`` components. A fixed ``n_select`` therefore
+        defines one scalar model score suitable for whole-epoch validation.
+        """
+        del y
+        check_is_fitted(self, "dss_")
+        if self.n_select is None:
+            raise ValueError("score requires an explicit n_select")
+        data, _, _, _, _ = self._prepare_epochs(X, fitting=False)
+        sources, start, stop = self._sources(data)
+        selected = sources[: int(self.n_select)]
+        weights = _observation_weights(
+            sample_weight,
+            n_times=data.shape[1],
+            n_epochs=data.shape[2],
+            lags=self.lag_samples_,
+            start=start,
+            stop=stop,
+        )
+        weight_per_time = weights.sum(axis=1)
+        valid_times = weight_per_time > 0
+        average = np.einsum("cte,te->ct", selected, weights, optimize=True)
+        average[:, valid_times] /= weight_per_time[valid_times]
+        evoked_power = float(
+            np.sum(average[:, valid_times] ** 2 * weight_per_time[valid_times])
+            / weight_per_time[valid_times].sum()
+        )
+        total_power = float(
+            np.sum(selected**2 * weights[np.newaxis, :, :]) / weights.sum()
+        )
+        return evoked_power / total_power if total_power > 0 else 0.0
+
+    def transform(self, X: BaseEpochs | np.ndarray) -> BaseEpochs | np.ndarray:
+        """Extract components or apply the fitted sensor-space operation."""
+        check_is_fitted(self, "dss_")
+        self._validate_parameters()
+        data, _, mne_type, orig, picks = self._prepare_epochs(X, fitting=False)
+        sources, start, stop = self._sources(data)
+        if self.component_action == "extract":
+            if orig is not None:
+                return np.transpose(sources, (2, 0, 1))
+            return sources
+
+        count = int(self.n_select)
+        selected = self.patterns_[:, :count] @ sources[:count].reshape(count, -1)
+        selected = selected.reshape(data.shape[0], stop - start, data.shape[2])
+        if self.component_action == "retain":
+            valid_output = selected + self.sensor_mean_.reshape(data.shape[0], 1, 1)
+        else:
+            valid_output = data[:, start:stop, :] - selected
+        output = data.copy()
+        output[:, start:stop, :] = valid_output
+        if orig is None:
+            return output
+        return reconstruct_mne_object(
+            np.transpose(output, (2, 0, 1)),
+            orig,
+            mne_type,
+            picks=picks,
+            verbose=False,
+        )
 
 
 def smooth_dss(
@@ -73,31 +522,24 @@ def smooth_dss(
     n_components: int | None = None,
     **dss_kws,
 ) -> DSS:
-    """Create a DSS configured for temporally smooth sources.
-
-    Returns a pre-configured DSS that extracts components with
-    low-frequency temporal structure.
+    """Create an ordinary DSS configured for temporally smooth sources.
 
     Parameters
     ----------
     window : int
-        Smoothing window size in samples. Default 10.
-    n_components : int, optional
-        Number of DSS components to keep. If None, keep all.
+        Smoothing window in samples.
+    n_components : int | None
+        Number of DSS components to fit. ``None`` keeps the available rank.
     **dss_kws
-        Additional keyword arguments passed to `DSS`.
+        Additional keyword arguments passed to :class:`DSS`.
 
     Returns
     -------
     dss : DSS
-        A DSS object configured with a SmoothingBias.
-
-    Examples
-    --------
-    >>> # Extract slow components
-    >>> dss = smooth_dss(window=20)
-    >>> dss.fit(data)
-    >>> slow_sources = dss.transform(data)
+        DSS configured with :class:`~mne_denoise.dss.SmoothingBias`.
     """
     bias = SmoothingBias(window=window)
     return DSS(bias=bias, n_components=n_components, **dss_kws)
+
+
+__all__ = ["TimeShiftDSS", "smooth_dss"]

--- a/mne_denoise/ssa/_common.py
+++ b/mne_denoise/ssa/_common.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from numbers import Integral, Real
+from numbers import Real
 from typing import Any
 
 import numpy as np
@@ -13,19 +13,11 @@ from .._logging import set_log_level_from_verbose
 from .._validation import (
     check_channel_first_data,
     check_channel_layout,
+    check_positive_integer,
     check_sfreq,
     resolve_sfreq,
 )
 from ..utils import extract_data_from_mne, reconstruct_mne_object
-
-
-def _check_positive_integer(value: int, *, name: str) -> int:
-    """Validate a positive integer parameter."""
-    if isinstance(value, bool) or not isinstance(value, Integral):
-        raise TypeError(f"{name} must be a positive integer")
-    if value < 1:
-        raise ValueError(f"{name} must be a positive integer")
-    return int(value)
 
 
 def _resolve_window_length(
@@ -39,7 +31,7 @@ def _resolve_window_length(
     """Resolve an SSA embedding dimension in the canonical ``L <= K`` range."""
     if n_times < 3:
         raise ValueError("SSA requires at least 3 time samples")
-    max_window = _check_positive_integer(max_window, name="max_window")
+    max_window = check_positive_integer(max_window, name="max_window")
     if max_window < 2:
         raise ValueError("max_window must be at least 2")
     if window_length is not None and window_seconds is not None:
@@ -53,7 +45,7 @@ def _resolve_window_length(
         sfreq = check_sfreq(sfreq, context="window_seconds")
         resolved = int(np.floor(window_seconds * sfreq + 0.5))
     elif window_length is not None:
-        resolved = _check_positive_integer(window_length, name="window_length")
+        resolved = check_positive_integer(window_length, name="window_length")
     elif sfreq is not None:
         sfreq = check_sfreq(sfreq)
         resolved = min(int(np.floor(0.5 * sfreq + 0.5)), max_window, (n_times + 1) // 2)

--- a/mne_denoise/ssa/basic.py
+++ b/mne_denoise/ssa/basic.py
@@ -22,10 +22,9 @@ from typing import Any
 
 import numpy as np
 
-from .._validation import check_channel_first_data, check_sfreq
+from .._validation import check_channel_first_data, check_positive_integer, check_sfreq
 from ._common import (
     _BaseSSATransformer,
-    _check_positive_integer,
     _diagonal_average,
     _resolve_window_length,
     _trajectory_matrix,
@@ -171,7 +170,7 @@ def ssa_w_correlation(components: np.ndarray, window_length: int) -> np.ndarray:
     components = np.asarray(components, dtype=np.float64)
     if components.ndim != 2 or components.shape[1] < 1:
         raise ValueError("components must have shape (n_components, n_times)")
-    window_length = _check_positive_integer(window_length, name="window_length")
+    window_length = check_positive_integer(window_length, name="window_length")
     n_times = components.shape[1]
     n_columns = n_times - window_length + 1
     if window_length > n_columns or window_length < 2:
@@ -227,7 +226,7 @@ def _check_frequency_parameters(
             raise ValueError("drop_band must satisfy 0 <= low < high <= Nyquist")
         drop_band = (low, high)
     if n_check is not None:
-        n_check = _check_positive_integer(n_check, name="n_check")
+        n_check = check_positive_integer(n_check, name="n_check")
     return sfreq, drop_freq_max, drop_band, n_check
 
 

--- a/mne_denoise/ssa/local.py
+++ b/mne_denoise/ssa/local.py
@@ -27,10 +27,9 @@ from typing import Any
 import numpy as np
 from sklearn.cluster import KMeans
 
-from .._validation import check_channel_first_data, check_sfreq
+from .._validation import check_channel_first_data, check_positive_integer, check_sfreq
 from ._common import (
     _BaseSSATransformer,
-    _check_positive_integer,
     _diagonal_average,
     _resolve_window_length,
     _trajectory_matrix,
@@ -139,8 +138,8 @@ def _check_local_parameters(
 ) -> tuple[int | str, int, int | None]:
     """Validate local SSA clustering parameters."""
     if n_clusters != "auto":
-        n_clusters = _check_positive_integer(n_clusters, name="n_clusters")
-    max_clusters = _check_positive_integer(max_clusters, name="max_clusters")
+        n_clusters = check_positive_integer(n_clusters, name="n_clusters")
+    max_clusters = check_positive_integer(max_clusters, name="max_clusters")
     if random_state is not None:
         if isinstance(random_state, bool) or not isinstance(random_state, Integral):
             raise TypeError("random_state must be an integer or None")

--- a/scripts/validate_time_shift_dss.py
+++ b/scripts/validate_time_shift_dss.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python
+"""Run the checked scientific validation for TimeShiftDSS.
+
+The default run uses the source-scale dimensions from de Cheveigne (2010), 100
+whole-trial bootstrap refits, and 1000 full-pipeline null surrogates. Use
+``--quick`` only for local smoke testing; quick output is marked accordingly
+and is not suitable as PR evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import platform
+import warnings
+from pathlib import Path
+
+import matplotlib
+import numpy as np
+import scipy
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import mne  # noqa: E402
+import sklearn  # noqa: E402
+from sklearn.base import clone  # noqa: E402
+from sklearn.model_selection import KFold  # noqa: E402
+
+from mne_denoise import __version__  # noqa: E402
+from mne_denoise.dss import (  # noqa: E402
+    DSS,
+    AverageBias,
+    TimeShiftDSS,
+)
+from mne_denoise.dss.variants.tsr import (  # noqa: E402
+    _lag_augment,
+    _resolve_lags,
+)
+
+
+def _rms(data):
+    """Return root-mean-square amplitude."""
+    return float(np.sqrt(np.mean(np.asarray(data) ** 2)))
+
+
+def _snr_db(target, interference):
+    """Return RMS target-to-interference ratio in decibels."""
+    return float(20 * np.log10(_rms(target) / _rms(interference)))
+
+
+def _whitening_rank(data, lags, requested_rank, reg=1e-9):
+    """Compute the costly numerical-rank diagnostic only for validation."""
+    augmented, _, _ = _lag_augment(data, tuple(lags))
+    singular_values = np.linalg.svd(
+        augmented.reshape(augmented.shape[0], -1), compute_uv=False
+    )
+    numerical_rank = np.count_nonzero(
+        singular_values**2 > reg * singular_values[0] ** 2
+    )
+    return min(requested_rank, int(numerical_rank))
+
+
+def _time_shift_dss_surrogate_test(
+    estimator,
+    data,
+    *,
+    n_surrogates,
+    n_splits,
+    alpha=0.05,
+    random_state=0,
+):
+    """Calibrate one fixed TSDSS model for this validation experiment."""
+    data = np.asarray(data, dtype=np.float64)
+    if data.ndim != 3 or data.shape[2] < n_splits:
+        raise ValueError("data must provide enough complete epochs for n_splits")
+    if estimator.n_select is None:
+        raise ValueError("surrogate validation requires an explicit n_select")
+    lags, _, _ = _resolve_lags(
+        lag_samples=estimator.lag_samples,
+        lag_times=estimator.lag_times,
+        sfreq=estimator.sfreq,
+    )
+    min_shift = max(lags) - min(lags) + 1
+    shifts = np.arange(min_shift, data.shape[1] - min_shift + 1)
+    if shifts.size == 0:
+        raise ValueError("Epochs are too short for a lag-destroying surrogate")
+    folds = list(
+        KFold(n_splits=n_splits, shuffle=True, random_state=random_state).split(
+            np.arange(data.shape[2])
+        )
+    )
+    if any(train.size < 2 or test.size < 2 for train, test in folds):
+        raise ValueError("Every fold must contain at least two complete epochs")
+
+    def _statistic(candidate):
+        scores = []
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message="The augmented feature count approaches"
+            )
+            for train, test in folds:
+                fitted = clone(estimator).fit(candidate[:, :, train])
+                scores.append(fitted.score(candidate[:, :, test]))
+        return float(np.mean(scores))
+
+    observed = _statistic(data)
+    rng = np.random.default_rng(random_state)
+    null_scores = np.empty(n_surrogates)
+    for index in range(n_surrogates):
+        surrogate = np.empty_like(data)
+        for epoch in range(data.shape[2]):
+            surrogate[:, :, epoch] = np.roll(
+                data[:, :, epoch], int(rng.choice(shifts)), axis=1
+            )
+        null_scores[index] = _statistic(surrogate)
+    threshold = float(np.quantile(null_scores, 1.0 - alpha, method="higher"))
+    pvalue = float((1 + np.count_nonzero(null_scores >= observed)) / (n_surrogates + 1))
+    return {
+        "observed_score": observed,
+        "null_scores": null_scores,
+        "threshold": threshold,
+        "pvalue": pvalue,
+        "promoted": bool(pvalue <= alpha),
+        "alpha": float(alpha),
+    }
+
+
+def _waveform_metrics(output, reference):
+    """Quantify sensor-unit target gain, shape, latency, and residual error."""
+    output = np.asarray(output).mean(axis=(0, 2))
+    reference = np.asarray(reference).mean(axis=(0, 2))
+    gain = float(np.dot(output, reference) / np.dot(reference, reference))
+    aligned = output if gain >= 0 else -output
+    gain = abs(gain)
+    correlation = float(abs(np.corrcoef(output, reference)[0, 1]))
+    cross = np.correlate(aligned, reference, mode="full")
+    latency = int(np.argmax(cross) - (reference.size - 1))
+    fitted = gain * reference
+    distortion = float(_rms(aligned - fitted) / max(_rms(fitted), np.finfo(float).eps))
+    return {
+        "target_gain": gain,
+        "target_waveform_correlation": correlation,
+        "target_latency_error_samples": latency,
+        "target_relative_rms_distortion": distortion,
+    }
+
+
+def _simulation_2(seed, *, n_times=1000, n_epochs=100):
+    """Generate de Cheveigne (2010) Simulation 2 with isolated contributions."""
+    rng = np.random.default_rng(seed)
+    n_channels, n_noise = 10, 5
+    waveform = np.sin(2 * np.pi * np.arange(n_times) / n_times)
+    target = np.broadcast_to(
+        waveform[np.newaxis, :, np.newaxis],
+        (n_channels, n_times, n_epochs),
+    ).copy()
+    sources = rng.standard_normal((n_noise, n_times + 1, n_epochs))
+    current_mixing = rng.standard_normal((n_channels, n_noise))
+    delayed_mixing = rng.standard_normal((n_channels, n_noise))
+    noise = np.einsum("jf,ftn->jtn", current_mixing, sources[:, 1:, :], optimize=True)
+    noise += np.einsum("jf,ftn->jtn", delayed_mixing, sources[:, :-1, :], optimize=True)
+    return target, noise
+
+
+def _scale_noise(target, noise, input_snr_db):
+    """Scale noise to an exact global RMS SNR."""
+    return noise * (_rms(target) / _rms(noise)) / 10 ** (input_snr_db / 20)
+
+
+def _fit_methods(train_data):
+    """Fit static and time-shift DSS with source-defined ranks."""
+    static = DSS(
+        bias=AverageBias(axis="epochs"),
+        n_components=1,
+        rank=10,
+        normalize_input=False,
+        component_action="retain",
+        n_select=1,
+    ).fit(train_data)
+    shifted = TimeShiftDSS(
+        lag_samples=[0, 1],
+        n_components=1,
+        # Five noise sources enter the two lag blocks at three time states
+        # (15 dimensions), plus one retained target direction. Rank sensitivity
+        # around this explicit choice is reported separately.
+        rank=16,
+        n_select=1,
+        component_action="retain",
+    ).fit(train_data)
+    return {"static_dss": static, "time_shift_dss": shifted}
+
+
+def _valid_output(estimator, data):
+    """Exclude package-preserved edge samples from FIR efficacy scoring."""
+    if isinstance(estimator, TimeShiftDSS):
+        return data[:, estimator.valid_slice_, :]
+    return data
+
+
+def _method_metrics(name, estimator, target, noise, input_snr_db):
+    """Apply one frozen sensor reconstruction to isolated contributions."""
+    target_output = _valid_output(estimator, estimator.transform(target))
+    noise_output = _valid_output(estimator, estimator.transform(noise))
+    target_reference = _valid_output(estimator, target)
+    noise_reference = _valid_output(estimator, noise)
+    row = {
+        "method": name,
+        "input_snr_db": float(input_snr_db),
+        "output_snr_db": _snr_db(target_output, noise_output),
+        "snr_improvement_db": _snr_db(target_output, noise_output) - input_snr_db,
+        "noise_attenuation_db": float(
+            20 * np.log10(_rms(noise_output) / _rms(noise_reference))
+        ),
+    }
+    row.update(_waveform_metrics(target_output, target_reference))
+    return row
+
+
+def _bootstrap_snr_delta(target, noise, *, n_resamples, seed):
+    """Refit both methods on resampled training trials and score fixed test trials."""
+    rng = np.random.default_rng(seed)
+    train_target, test_target = target[:, :, :80], target[:, :, 80:]
+    train_noise, test_noise = noise[:, :, :80], noise[:, :, 80:]
+    deltas = np.empty(n_resamples)
+    for index in range(n_resamples):
+        selection = rng.integers(0, train_target.shape[2], train_target.shape[2])
+        train = train_target[:, :, selection] + train_noise[:, :, selection]
+        methods = _fit_methods(train)
+        scores = {}
+        for name, estimator in methods.items():
+            scores[name] = _snr_db(
+                _valid_output(estimator, estimator.transform(test_target)),
+                _valid_output(estimator, estimator.transform(test_noise)),
+            )
+        deltas[index] = scores["time_shift_dss"] - scores["static_dss"]
+    return deltas
+
+
+def _distortion_fixture():
+    """Reproduce the shifted-waveform failure and optional CCA correction."""
+    n_times = 200
+    waveform = np.zeros(n_times)
+    support = np.arange(60, 100)
+    waveform[support] = np.sin(2 * np.pi * np.arange(support.size) / support.size)
+    data = np.broadcast_to(waveform[None, :, None], (1, n_times, 10)).copy()
+    params = {
+        "lag_samples": [0, 1, 2, 3, 4],
+        "n_components": 5,
+        "rank": 5,
+    }
+    plain = TimeShiftDSS(**params).fit(data).transform(data)[0, :, 0]
+    controlled = (
+        TimeShiftDSS(**params, distortion_control="cca")
+        .fit(data)
+        .transform(data)[0, :, 0]
+    )
+    reference = waveform[4:]
+    return {
+        "reference": reference,
+        "plain": plain,
+        "cca": controlled,
+        "plain_correlation": float(abs(np.corrcoef(reference, plain)[0, 1])),
+        "cca_correlation": float(abs(np.corrcoef(reference, controlled)[0, 1])),
+    }
+
+
+def _rank_lag_sensitivity(target, noise):
+    """Report the expected rank cliff and sensitivity to a longer lag grid."""
+    train = np.arange(80)
+    test = np.arange(80, 100)
+    rows = []
+    training_data = target[:, :, train] + noise[:, :, train]
+    for lags, ranks in (([0, 1], [15, 16, 17]), ([0, 1, 2], [20, 21, 22])):
+        for rank in ranks:
+            estimator = TimeShiftDSS(
+                lag_samples=lags,
+                n_components=1,
+                rank=rank,
+                n_select=1,
+                component_action="retain",
+            ).fit(training_data)
+            target_output = _valid_output(
+                estimator, estimator.transform(target[:, :, test])
+            )
+            noise_output = _valid_output(
+                estimator, estimator.transform(noise[:, :, test])
+            )
+            rows.append(
+                {
+                    "lag_samples": " ".join(str(value) for value in lags),
+                    "requested_rank": rank,
+                    "fitted_rank": _whitening_rank(training_data, lags, rank),
+                    "held_out_output_snr_db": _snr_db(target_output, noise_output),
+                }
+            )
+    return rows
+
+
+def _preservation_probe(estimator, *, n_times, n_epochs, seed):
+    """Measure how target retention treats an off-target neural oscillation."""
+    rng = np.random.default_rng(seed)
+    phases = rng.uniform(0.0, 2 * np.pi, n_epochs)
+    topography = rng.standard_normal(10)
+    time = np.arange(n_times) / 1000.0
+    waveform = np.sin(2 * np.pi * 10 * time[:, None] + phases[None, :])
+    neural = topography[:, None, None] * waveform[None, :, :]
+    retained = _valid_output(estimator, estimator.transform(neural))
+    neural = _valid_output(estimator, neural)
+    return {
+        "nontarget_neural_retained_power": float(
+            np.mean(retained**2) / np.mean(neural**2)
+        ),
+        "nontarget_neural_waveform_correlation": float(
+            abs(np.corrcoef(retained.ravel(), neural.ravel())[0, 1])
+        ),
+        "nontarget_neural_relative_rms_change": float(
+            _rms(retained - neural) / _rms(neural)
+        ),
+    }
+
+
+def _write_csv(path, rows):
+    """Write scalar method metrics with stable columns."""
+    with path.open("w", newline="", encoding="utf-8") as fid:
+        writer = csv.DictWriter(fid, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _plot(path, rows, distortion, bootstrap_delta):
+    """Save source simulation, distortion, and bootstrap evidence."""
+    figure, axes = plt.subplots(1, 3, figsize=(14, 4.2))
+    for method, label in (
+        ("static_dss", "Static DSS"),
+        ("time_shift_dss", "TimeShiftDSS"),
+    ):
+        selected = [row for row in rows if row["method"] == method]
+        axes[0].plot(
+            [row["input_snr_db"] for row in selected],
+            [row["output_snr_db"] for row in selected],
+            marker="o",
+            label=label,
+        )
+    axes[0].set(xlabel="Input SNR (dB)", ylabel="Held-out output SNR (dB)")
+    axes[0].legend()
+    axes[0].grid(alpha=0.25)
+
+    axes[1].plot(distortion["reference"], color="black", label="Undelayed")
+    axes[1].plot(distortion["plain"], label="Plain TSDSS")
+    axes[1].plot(distortion["cca"], label="CCA step 7")
+    axes[1].set(xlabel="Valid sample", ylabel="Arbitrary component units")
+    axes[1].legend()
+    axes[1].grid(alpha=0.25)
+
+    axes[2].hist(bootstrap_delta, bins=min(20, max(5, bootstrap_delta.size // 5)))
+    axes[2].axvline(0.0, color="black", linestyle="--")
+    axes[2].set(
+        xlabel="Held-out SNR gain over static DSS (dB)",
+        ylabel="Bootstrap refits",
+    )
+    axes[2].grid(alpha=0.25)
+    figure.tight_layout()
+    figure.savefig(path, dpi=160)
+    plt.close(figure)
+
+
+def main():
+    """Run validation and write machine-readable and visual artifacts."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("reports/time_shift_dss"),
+    )
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--n-surrogates", type=int, default=1000)
+    parser.add_argument("--n-bootstrap", type=int, default=100)
+    parser.add_argument("--quick", action="store_true")
+    args = parser.parse_args()
+    if args.quick:
+        args.n_surrogates = min(args.n_surrogates, 20)
+        args.n_bootstrap = min(args.n_bootstrap, 20)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    target, base_noise = _simulation_2(args.seed)
+    train = np.arange(80)
+    test = np.arange(80, 100)
+    rows = []
+    fitted_at_minus_40 = None
+    noise_at_minus_40 = None
+    for input_snr_db in (-20.0, -40.0, -60.0):
+        noise = _scale_noise(target, base_noise, input_snr_db)
+        methods = _fit_methods(target[:, :, train] + noise[:, :, train])
+        for name, estimator in methods.items():
+            rows.append(
+                _method_metrics(
+                    name,
+                    estimator,
+                    target[:, :, test],
+                    noise[:, :, test],
+                    input_snr_db,
+                )
+            )
+        if input_snr_db == -40.0:
+            fitted_at_minus_40 = methods["time_shift_dss"]
+            noise_at_minus_40 = noise
+
+    bootstrap_delta = _bootstrap_snr_delta(
+        target,
+        noise_at_minus_40,
+        n_resamples=args.n_bootstrap,
+        seed=args.seed + 1,
+    )
+    distortion = _distortion_fixture()
+    preservation = _preservation_probe(
+        fitted_at_minus_40,
+        n_times=target.shape[1],
+        n_epochs=test.size,
+        seed=args.seed + 2,
+    )
+    sensitivity = _rank_lag_sensitivity(target, noise_at_minus_40)
+
+    pure_noise = np.random.default_rng(args.seed + 3).standard_normal(target.shape)
+    null_estimator = TimeShiftDSS(
+        lag_samples=[0, 1],
+        n_components=10,
+        rank=20,
+        n_select=1,
+    )
+    null = _time_shift_dss_surrogate_test(
+        null_estimator,
+        pure_noise,
+        n_surrogates=args.n_surrogates,
+        n_splits=5,
+        random_state=args.seed + 4,
+    )
+    time_shift_rows = [row for row in rows if row["method"] == "time_shift_dss"]
+
+    summary = {
+        "status": "quick-smoke" if args.quick else "source-scale",
+        "configuration": {
+            "base_main_commit": "625f4d5",
+            "seed": args.seed,
+            "n_surrogates": args.n_surrogates,
+            "n_bootstrap": args.n_bootstrap,
+            "simulation_2_shape": list(target.shape),
+            "train_epochs": 80,
+            "test_epochs": 20,
+            "explicit_lags": [0, 1],
+            "time_shift_rank": 16,
+        },
+        "environment": {
+            "python": platform.python_version(),
+            "mne_denoise": __version__,
+            "numpy": np.__version__,
+            "scipy": scipy.__version__,
+            "sklearn": sklearn.__version__,
+            "mne": mne.__version__,
+        },
+        "bootstrap_snr_delta_db": {
+            "mean": float(bootstrap_delta.mean()),
+            "lower_95": float(np.quantile(bootstrap_delta, 0.025)),
+            "upper_95": float(np.quantile(bootstrap_delta, 0.975)),
+        },
+        "pure_noise_max_null": {
+            "observed_score": null["observed_score"],
+            "threshold_95": null["threshold"],
+            "pvalue": null["pvalue"],
+            "promoted": null["promoted"],
+        },
+        "figure_6_distortion": {
+            "plain_correlation": distortion["plain_correlation"],
+            "cca_correlation": distortion["cca_correlation"],
+        },
+        "off_target_neural_probe": preservation,
+        "rank_lag_sensitivity": sensitivity,
+        "acceptance": {
+            "time_shift_beats_static_at_all_snrs": all(
+                next(
+                    row["output_snr_db"]
+                    for row in rows
+                    if row["method"] == "time_shift_dss" and row["input_snr_db"] == snr
+                )
+                > next(
+                    row["output_snr_db"]
+                    for row in rows
+                    if row["method"] == "static_dss" and row["input_snr_db"] == snr
+                )
+                for snr in (-20.0, -40.0, -60.0)
+            ),
+            "bootstrap_delta_ci_excludes_zero": bool(
+                np.quantile(bootstrap_delta, 0.025) > 0
+            ),
+            "pure_noise_abstains": not null["promoted"],
+            "cca_reduces_distortion": bool(
+                distortion["cca_correlation"] > distortion["plain_correlation"]
+            ),
+            "target_shape_preserved": all(
+                row["target_waveform_correlation"] > 0.999
+                and row["target_latency_error_samples"] == 0
+                and row["target_relative_rms_distortion"] < 0.01
+                for row in time_shift_rows
+            ),
+        },
+    }
+    _write_csv(args.output_dir / "simulation_2_metrics.csv", rows)
+    _write_csv(args.output_dir / "rank_lag_sensitivity.csv", sensitivity)
+    (args.output_dir / "validation_summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    np.savetxt(args.output_dir / "pure_noise_null_scores.csv", null["null_scores"])
+    np.savetxt(args.output_dir / "bootstrap_snr_delta_db.csv", bootstrap_delta)
+    _plot(
+        args.output_dir / "time_shift_dss_validation.png",
+        rows,
+        distortion,
+        bootstrap_delta,
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    if not all(summary["acceptance"].values()):
+        raise SystemExit("One or more pre-registered validation gates failed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/denoisers/test_averaging.py
+++ b/tests/denoisers/test_averaging.py
@@ -74,6 +74,24 @@ def test_average_bias_weight_mismatch():
         bias.apply(data)
 
 
+@pytest.mark.parametrize(
+    "weights, match",
+    [
+        ([np.nan, 1.0], "finite and non-negative"),
+        ([-1.0, 1.0], "finite and non-negative"),
+        ([0.0, 0.0], "positive sum"),
+        (np.zeros((3, 2)), "positive observation"),
+        (np.ones((2, 2)), "weights must have shape"),
+    ],
+)
+def test_average_bias_epochs_invalid_weights(weights, match):
+    """Epoch weights reject invalid values, mass, and observation shapes."""
+    data = np.ones((1, 3, 2))
+
+    with pytest.raises(ValueError, match=match):
+        AverageBias(axis="epochs", weights=weights).apply(data)
+
+
 def test_average_bias_datasets():
     """Test AverageBias(axis='datasets') uniform averaging."""
     rng = np.random.RandomState(0)
@@ -110,6 +128,23 @@ def test_average_bias_datasets_errors():
     bias_w = AverageBias(axis="datasets", weights=np.ones(5))
     with pytest.raises(ValueError, match="weights length"):
         bias_w.apply(data)
+
+
+@pytest.mark.parametrize(
+    "weights, match",
+    [
+        (np.ones((3, 1)), "weights must have shape"),
+        ([np.nan, 1.0, 1.0], "finite and non-negative"),
+        ([-1.0, 1.0, 1.0], "finite and non-negative"),
+        ([0.0, 0.0, 0.0], "positive sum"),
+    ],
+)
+def test_average_bias_datasets_invalid_weights(weights, match):
+    """Dataset weights reject invalid values, mass, and shapes."""
+    data = np.ones((3, 2, 4))
+
+    with pytest.raises(ValueError, match=match):
+        AverageBias(axis="datasets", weights=weights).apply(data)
 
 
 def test_average_bias_properties():

--- a/tests/denoisers/test_averaging.py
+++ b/tests/denoisers/test_averaging.py
@@ -40,6 +40,18 @@ def test_average_bias_epochs_weighted():
     assert_allclose(biased[0, 0, :], 12)
 
 
+def test_average_bias_epochs_observation_weighted():
+    """Time-by-epoch weights produce a separate average at every time."""
+    data = np.array([[[1.0, 3.0], [10.0, 20.0], [4.0, 8.0]]])
+    weights = np.array([[1.0, 1.0], [1.0, 3.0], [0.0, 0.0]])
+
+    biased = AverageBias(axis="epochs", weights=weights).apply(data)
+
+    expected = np.array([[2.0, 17.5, 0.0]])
+    assert_allclose(biased[:, :, 0], expected)
+    assert_allclose(biased[:, :, 1], expected)
+
+
 def test_average_bias_epochs_errors():
     """Test error handling for epochs axis."""
     bias = AverageBias(axis="epochs")

--- a/tests/denoisers/test_temporal.py
+++ b/tests/denoisers/test_temporal.py
@@ -1,104 +1,129 @@
-"""Unit tests for temporal denoisers (TimeShiftBias, SmoothingBias)."""
+"""Unit tests for temporal denoisers."""
 
 import numpy as np
 import pytest
 
 from mne_denoise.dss.denoisers.temporal import (
     DCTDenoiser,
+    LagAverageBias,
     SmoothingBias,
-    TimeShiftBias,
 )
 
 
-def test_timeshift_basic_2d():
-    """Test TimeShiftBias with 2D data."""
+def test_lag_average_basic_2d():
+    """Test LagAverageBias with 2D data."""
     rng = np.random.default_rng(42)
     n_ch, n_times = 3, 200
     data = rng.normal(0, 1, (n_ch, n_times))
 
-    bias = TimeShiftBias(shifts=5)
+    bias = LagAverageBias(lags=5)
     biased = bias.apply(data)
 
     assert biased.shape == data.shape
 
 
-def test_timeshift_basic_3d():
-    """Test TimeShiftBias with 3D epoched data."""
+def test_lag_average_basic_3d():
+    """Test LagAverageBias with 3D epoched data."""
     rng = np.random.default_rng(42)
     n_ch, n_times, n_epochs = 3, 200, 4
     data = rng.normal(0, 1, (n_ch, n_times, n_epochs))
 
-    bias = TimeShiftBias(shifts=5)
+    bias = LagAverageBias(lags=5)
     biased = bias.apply(data)
 
     assert biased.shape == data.shape
     assert biased.ndim == 3
 
 
-def test_shifts_as_array():
-    """Test TimeShiftBias with shifts specified as array."""
+def test_lag_average_3d_never_crosses_epoch_boundaries():
+    """Every epoch is lagged independently along its time axis."""
+    data = np.array([[[0, 100], [1, 101], [2, 102], [3, 103], [4, 104], [5, 105]]])
+
+    biased = LagAverageBias(lags=[1]).apply(data)
+
+    np.testing.assert_array_equal(biased[0, :, 0], [0, 2, 3, 4, 5, 0])
+    np.testing.assert_array_equal(biased[0, :, 1], [0, 102, 103, 104, 105, 0])
+    assert np.issubdtype(biased.dtype, np.floating)
+
+
+def test_lags_as_array():
+    """Test explicit lag arrays."""
     rng = np.random.default_rng(42)
     data = rng.normal(0, 1, (2, 100))
 
-    shifts = np.array([1, 2, 5, 10])
-    bias = TimeShiftBias(shifts=shifts)
+    lags = np.array([1, 2, 5, 10])
+    bias = LagAverageBias(lags=lags)
     biased = bias.apply(data)
 
     assert biased.shape == data.shape
 
 
-def test_autocorrelation_method():
-    """Test TimeShiftBias with autocorrelation method."""
+def test_uniform_weighting():
+    """Test equal weighting across lags."""
     rng = np.random.default_rng(42)
     data = rng.normal(0, 1, (2, 100))
 
-    bias = TimeShiftBias(shifts=5, method="autocorrelation")
+    bias = LagAverageBias(lags=5, weighting="uniform")
     biased = bias.apply(data)
 
     assert biased.shape == data.shape
 
 
-def test_prediction_method():
-    """Test TimeShiftBias with prediction method."""
+def test_inverse_lag_weighting():
+    """Test inverse-lag weighting."""
     rng = np.random.default_rng(42)
     data = rng.normal(0, 1, (2, 100))
 
-    bias = TimeShiftBias(shifts=5, method="prediction")
+    bias = LagAverageBias(lags=5, weighting="inverse_lag")
     biased = bias.apply(data)
 
     assert biased.shape == data.shape
 
 
-def test_unknown_method_error():
-    """Test TimeShiftBias raises error for unknown method."""
+def test_unknown_weighting_error():
+    """Reject unknown weighting rules."""
     rng = np.random.default_rng(42)
     data = rng.normal(0, 1, (2, 100))
 
-    bias = TimeShiftBias(shifts=5, method="unknown")
-    with pytest.raises(ValueError, match="Unknown method"):
+    bias = LagAverageBias(lags=5, weighting="unknown")
+    with pytest.raises(ValueError, match="weighting must be"):
         bias.apply(data)
 
 
+@pytest.mark.parametrize("lags", [0, -1, [], [0]])
+def test_invalid_lags(lags):
+    """Reject empty or non-operational lag declarations."""
+    with pytest.raises(ValueError, match="lags must"):
+        LagAverageBias(lags=lags).apply(np.ones((2, 20)))
+
+
+@pytest.mark.parametrize("lags", [True, [1.5], [False, 1]])
+def test_non_integer_lags(lags):
+    """Reject booleans and fractional lags."""
+    with pytest.raises(TypeError, match="lags must"):
+        LagAverageBias(lags=lags).apply(np.ones((2, 20)))
+
+
 def test_shift_too_large_error():
-    """Test TimeShiftBias raises error when shift too large."""
+    """Test LagAverageBias raises error when lag is too large."""
     data = np.ones((2, 20))
 
-    bias = TimeShiftBias(shifts=15)  # Too large for data length 20
+    bias = LagAverageBias(lags=15)  # Too large for data length 20
     with pytest.raises(ValueError, match="too large"):
         bias.apply(data)
 
 
 def test_data_too_short_error():
-    """Test TimeShiftBias raises error when data too short."""
+    """Test LagAverageBias raises error when data is too short."""
     data = np.ones((2, 10))
 
-    bias = TimeShiftBias(shifts=5)
+    bias = LagAverageBias(lags=5)
     with pytest.raises(ValueError, match="too short|too large"):
         bias.apply(data)
 
 
 def test_autocorrelated_signal_preserved():
-    """Test TimeShiftBias preserves autocorrelated signals."""
+    """Test LagAverageBias preserves autocorrelated signals."""
     n_times = 500
     times = np.arange(n_times) / 100
 
@@ -111,7 +136,7 @@ def test_autocorrelated_signal_preserved():
 
     data = (slow_signal + fast_noise)[np.newaxis, :]
 
-    bias = TimeShiftBias(shifts=10)
+    bias = LagAverageBias(lags=10)
     biased = bias.apply(data)
 
     # Slow signal should be better correlated with biased output

--- a/tests/test_cca_utils.py
+++ b/tests/test_cca_utils.py
@@ -78,6 +78,42 @@ def test_cca_unit_variance(rng):
     np.testing.assert_allclose(V.std(axis=0, ddof=1), 1.0, atol=1e-10)
 
 
+def test_weighted_cca_matches_repeated_observations(rng):
+    """Integer observation weights match explicit row replication."""
+    X = rng.standard_normal((80, 5))
+    Y = X[:, :3] @ rng.standard_normal((3, 4)) + 0.2 * rng.standard_normal((80, 4))
+    weights = rng.integers(1, 4, size=80)
+
+    _, _, weighted, U, V = canonical_correlation(X, Y, sample_weight=weights)
+    _, _, repeated, _, _ = canonical_correlation(
+        np.repeat(X, weights, axis=0), np.repeat(Y, weights, axis=0)
+    )
+
+    np.testing.assert_allclose(weighted, repeated, atol=1e-12)
+    np.testing.assert_allclose(
+        np.sqrt(weights @ (U**2) / weights.sum()), 1.0, atol=1e-12
+    )
+    np.testing.assert_allclose(
+        np.sqrt(weights @ (V**2) / weights.sum()), 1.0, atol=1e-12
+    )
+
+
+@pytest.mark.parametrize(
+    "weights, match",
+    [
+        (np.ones(9), "shape"),
+        (np.r_[np.ones(9), np.nan], "finite"),
+        (np.r_[np.ones(9), -1.0], "non-negative"),
+        (np.zeros(10), "positive sum"),
+    ],
+)
+def test_weighted_cca_rejects_invalid_weights(weights, match):
+    """Weighted CCA validates its observation measure."""
+    X = np.arange(20.0).reshape(10, 2)
+    with pytest.raises(ValueError, match=match):
+        canonical_correlation(X, X, sample_weight=weights)
+
+
 def test_cca_mismatched_samples_raises(rng):
     """Different n_samples raises ValueError."""
     X = rng.standard_normal((100, 5))

--- a/tests/test_linear_dss.py
+++ b/tests/test_linear_dss.py
@@ -219,6 +219,56 @@ def test_dss_fit_transform():
     assert dss.eigenvalues_ is not None
 
 
+def test_dss_uses_fitted_mean_across_transform_batches():
+    """Unrelated transform observations cannot change frozen DSS sources."""
+    rng = np.random.default_rng(12)
+    train = rng.standard_normal((3, 200)) + np.array([[1.0], [4.0], [-2.0]])
+    held_out = rng.standard_normal((3, 40))
+    unrelated = rng.standard_normal((3, 60)) * 30.0 + 100.0
+    dss = DSS(bias=lambda values: values, n_components=3, normalize_input=False)
+    dss.fit(train)
+
+    prefix = dss.transform(held_out)
+    combined = dss.transform(np.concatenate([held_out, unrelated], axis=1))
+
+    assert_allclose(combined[:, : held_out.shape[1]], prefix, atol=1e-12)
+    assert_allclose(dss.mean_[:, 0], train.mean(axis=1))
+
+
+def test_dss_center_false_uses_uncentered_second_moments():
+    """Explicit uncentered DSS leaves offsets in its component transform."""
+    data = np.array([[1.0, 2.0, 3.0], [10.0, 10.0, 10.0]])
+    dss = DSS(
+        bias=lambda values: values,
+        n_components=2,
+        normalize_input=False,
+        center=False,
+    ).fit(data)
+
+    assert_allclose(dss.mean_, 0.0)
+    assert_allclose(dss.transform(data), dss.filters_ @ data)
+
+
+def test_dss_centering_does_not_change_bias_input():
+    """The transform origin must not alter the physical bias operation."""
+    data = np.arange(12.0).reshape(3, 4) + 10.0
+    received = []
+
+    def bias(values):
+        received.append(values.copy())
+        return values
+
+    DSS(bias=bias, normalize_input=False, center=True).fit(data)
+
+    assert_allclose(received[0], data)
+
+
+def test_dss_rejects_non_boolean_center():
+    """Centering semantics must be explicit rather than truthy."""
+    with pytest.raises(TypeError, match="center must be a bool"):
+        DSS(bias=lambda values: values, center=1).fit(np.eye(3))
+
+
 def test_dss_custom_bias_callable():
     """DSS should accept custom callable bias."""
     rng = np.random.default_rng(42)

--- a/tests/utils/test_covariance.py
+++ b/tests/utils/test_covariance.py
@@ -143,17 +143,33 @@ def test_covariance_3d_data():
 
 
 def test_covariance_3d_with_weights():
-    """Test covariance with 3D data and per-time-point weights."""
-    rng = np.random.default_rng(42)
-    n_ch, n_times, n_epochs = 3, 100, 5
-    data = rng.standard_normal((n_ch, n_times, n_epochs))
-
-    # Weights matching n_times (will be tiled)
-    weights = rng.uniform(0.5, 1.5, n_times)
+    """Per-time weights broadcast across epochs in flattened data order."""
+    data = np.array(
+        [
+            [[1.0, 10.0], [2.0, 20.0], [4.0, 40.0]],
+            [[3.0, 30.0], [5.0, 50.0], [9.0, 90.0]],
+        ]
+    )
+    weights = np.array([1.0, 2.0, 7.0])
+    expected_weights = np.repeat(weights, data.shape[2])
+    flattened = data.reshape(data.shape[0], -1)
 
     cov = compute_covariance(data, weights=weights)
+    expected = compute_covariance(flattened, weights=expected_weights)
 
-    assert cov.shape == (n_ch, n_ch)
+    assert_allclose(cov, expected)
+
+
+def test_covariance_3d_weight_matrix_matches_c_order_flattening():
+    """A time-by-epoch weight matrix aligns exactly with C-order samples."""
+    rng = np.random.default_rng(42)
+    data = rng.standard_normal((3, 5, 4))
+    weights = np.arange(1.0, 21.0).reshape(5, 4)
+
+    matrix_result = compute_covariance(data, weights=weights)
+    flat_result = compute_covariance(data.reshape(3, -1), weights=weights.reshape(-1))
+
+    assert_allclose(matrix_result, flat_result)
 
 
 def test_covariance_3d_with_full_weights():
@@ -186,8 +202,28 @@ def test_covariance_zero_weights_error():
     data = rng.standard_normal((3, 100))
     weights = np.zeros(100)  # All zero weights
 
-    with pytest.raises(ValueError, match="Sum of weights is zero"):
+    with pytest.raises(ValueError, match="Sum of weights must be positive"):
         compute_covariance(data, weights=weights)
+
+
+@pytest.mark.parametrize(
+    "weights, match",
+    [
+        (np.array([1.0, -1.0, 1.0]), "non-negative"),
+        (np.array([1.0, np.nan, 1.0]), "finite"),
+        (np.ones((3, 1)), "one-dimensional"),
+    ],
+)
+def test_covariance_rejects_invalid_2d_weights(weights, match):
+    """Weights are a finite, nonnegative one-dimensional sample measure."""
+    with pytest.raises(ValueError, match=match):
+        compute_covariance(np.ones((2, 3)), weights=weights)
+
+
+def test_covariance_rejects_invalid_3d_weight_shape():
+    """Three-dimensional weights must follow an explicit supported layout."""
+    with pytest.raises(ValueError, match="For 3D data"):
+        compute_covariance(np.ones((2, 3, 4)), weights=np.ones((4, 3)))
 
 
 def test_covariance_weighted_non_empirical_error():

--- a/tests/utils/test_whitening.py
+++ b/tests/utils/test_whitening.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from mne_denoise._spatial import apply_spatial_transform
+from mne_denoise._spatial import apply_spatial_transform, fit_mixing_matrix
 from mne_denoise.dss.utils.whitening import (
     apply_covariance_transform,
     compute_data_covariance_whitener,
@@ -54,6 +54,20 @@ def test_apply_spatial_transform_rejects_invalid_chunk_size(chunk_size):
     """The shared chunk size has one validated contract."""
     with pytest.raises((TypeError, ValueError), match="chunk_size"):
         apply_spatial_transform(np.eye(3), np.ones((3, 10)), chunk_size=chunk_size)
+
+
+def test_fit_mixing_matrix_weighted_epoched_data():
+    """Shared weighted regression recovers a sensor projection."""
+    rng = np.random.default_rng(42)
+    sources = rng.standard_normal((2, 20, 4))
+    expected = np.array([[1.0, 2.0], [-0.5, 0.25], [3.0, -1.0]])
+    data = np.einsum("cs,ste->cte", expected, sources)
+    weights = np.ones((20, 4))
+    weights[:3, 0] = 0.0
+
+    mixing = fit_mixing_matrix(data, sources, sample_weight=weights)
+
+    np.testing.assert_allclose(mixing, expected, atol=1e-12)
 
 
 def test_apply_covariance_transform():

--- a/tests/variants/test_tsr.py
+++ b/tests/variants/test_tsr.py
@@ -1,9 +1,16 @@
 import mne
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+from sklearn.base import clone
 
-from mne_denoise.dss.denoisers.temporal import SmoothingBias, TimeShiftBias
-from mne_denoise.dss.variants.tsr import smooth_dss, time_shift_dss
+from mne_denoise.dss import DSS, AverageBias, TimeShiftDSS
+from mne_denoise.dss.denoisers.temporal import LagAverageBias, SmoothingBias
+from mne_denoise.dss.variants.tsr import (
+    _lag_augment,
+    _observation_weights,
+    smooth_dss,
+)
 
 
 @pytest.fixture
@@ -32,7 +39,7 @@ def slow_data_generator():
 
 def test_tsr_array(slow_data_generator):
     data, slow = slow_data_generator((3, 500))
-    dss = time_shift_dss(shifts=10, n_components=3)
+    dss = DSS(bias=LagAverageBias(lags=10), n_components=3)
     dss.fit(data)
 
     sources = dss.transform(data)
@@ -46,7 +53,7 @@ def test_tsr_raw(slow_data_generator):
     info = mne.create_info(3, 100, "eeg")
     raw = mne.io.RawArray(data, info, verbose=False)
 
-    dss = time_shift_dss(shifts=10, n_components=3)
+    dss = DSS(bias=LagAverageBias(lags=10), n_components=3)
     dss.fit(raw)
 
     sources = dss.transform(raw)
@@ -59,7 +66,7 @@ def test_tsr_epochs(slow_data_generator):
     info = mne.create_info(3, 100, "eeg")
     epochs = mne.EpochsArray(data, info, verbose=False)
 
-    dss = time_shift_dss(shifts=10, n_components=2)
+    dss = DSS(bias=LagAverageBias(lags=10), n_components=2)
     dss.fit(epochs)
 
     sources = dss.transform(epochs)
@@ -92,8 +99,8 @@ def test_tsr_3d_bias_unit():
     rng = np.random.default_rng(42)
     data_3d = rng.standard_normal((3, 20, 5))  # (ch, times, epochs)
 
-    # 1. TimeShiftBias
-    bias = TimeShiftBias(shifts=2)
+    # 1. LagAverageBias
+    bias = LagAverageBias(lags=2)
     out_3d = bias.apply(data_3d)
     assert out_3d.shape == data_3d.shape
     assert out_3d.ndim == 3
@@ -105,14 +112,347 @@ def test_tsr_3d_bias_unit():
     assert out_smooth.ndim == 3
 
 
-def test_tsr_prediction_method(slow_data_generator):
-    """Test functionality of prediction method."""
+def test_tsr_inverse_lag_weighting(slow_data_generator):
+    """Test inverse-lag weighting."""
     data, slow = slow_data_generator((3, 500))
 
-    dss = time_shift_dss(shifts=10, method="prediction", n_components=3)
+    dss = DSS(
+        bias=LagAverageBias(lags=10, weighting="inverse_lag"),
+        n_components=3,
+    )
     dss.fit(data)
 
     sources = dss.transform(data)
     # Should still extract the slow component
     corr = np.abs(np.corrcoef(sources[0], slow)[0, 1])
     assert corr > 0.8
+
+
+def _data(seed=0, shape=(3, 80, 8), offset=True):
+    """Create deterministic channel-by-time-by-epoch data."""
+    rng = np.random.default_rng(seed)
+    data = rng.standard_normal(shape)
+    if offset:
+        data += np.linspace(-2.0, 3.0, shape[0])[:, np.newaxis, np.newaxis]
+    return data
+
+
+def _estimator(**kwargs):
+    """Build a small explicit-rank estimator."""
+    params = {"lag_samples": [0, 1], "n_components": 4, "rank": 4}
+    params.update(kwargs)
+    return TimeShiftDSS(**params)
+
+
+def test_lag_augmentation_sign_and_epoch_isolation():
+    """Positive lags use past samples and never borrow adjacent epochs."""
+    data = np.array([[[0.0, 100.0], [1.0, 101.0], [2.0, 102.0], [3.0, 103.0]]])
+
+    augmented, start, stop = _lag_augment(data, (-1, 0, 1))
+
+    assert (start, stop) == (1, 3)
+    assert_array_equal(augmented[0], [[2.0, 102.0], [3.0, 103.0]])
+    assert_array_equal(augmented[1], [[1.0, 101.0], [2.0, 102.0]])
+    assert_array_equal(augmented[2], [[0.0, 100.0], [1.0, 101.0]])
+
+
+def test_lag_weights_use_minimum_across_touched_samples():
+    """A zero-weight source sample invalidates every lag window touching it."""
+    weights = np.ones((6, 2))
+    weights[2, 0] = 0.0
+
+    valid = _observation_weights(
+        weights,
+        n_times=6,
+        n_epochs=2,
+        lags=(0, 1, 2),
+        start=2,
+        stop=6,
+    )
+
+    # Reference times are 2..5. The bad source sample at t=2 is touched by
+    # reference windows t=2, 3, and 4, but only in epoch 0.
+    assert_array_equal(valid[:, 0], [0.0, 0.0, 0.0, 1.0])
+    assert_array_equal(valid[:, 1], np.ones(4))
+
+
+def test_extract_shapes_and_explicit_fitted_geometry():
+    """Extraction exposes source components only on common valid support."""
+    data = _data()
+    est = _estimator().fit(data)
+
+    sources = est.transform(data)
+
+    assert sources.shape == (4, 79, 8)
+    assert est.n_augmented_features_ == 6
+    assert est.positive_weight_observations_ == 79 * 8
+    assert est.effective_observations_ == pytest.approx(79 * 8)
+    assert est.valid_slice_ == slice(1, 80)
+    assert est.feature_mean_.shape == (6, 1)
+    assert_array_equal(est.feature_mean_, 0.0)
+
+
+def test_wrapper_composes_trial_average_dss_on_lag_features():
+    """TimeShiftDSS adds lags and delegates decomposition to the DSS estimator."""
+    data = _data(seed=30)
+    augmented, _, _ = _lag_augment(data, (0, 1))
+    weights = np.ones(augmented.shape[1:])
+    reference = DSS(
+        bias=AverageBias(axis="epochs", weights=weights),
+        n_components=4,
+        rank=4,
+        reg=1e-9,
+        normalize_input=False,
+        center=False,
+    ).fit(augmented, weights=weights)
+
+    fitted = _estimator().fit(data)
+
+    assert isinstance(fitted.dss_, DSS)
+    assert isinstance(fitted.dss_.bias, AverageBias)
+    assert fitted.dss_.bias.axis == "epochs"
+    assert_allclose(fitted.eigenvalues_, reference.eigenvalues_, rtol=1e-12, atol=1e-12)
+    assert_allclose(
+        np.abs(fitted.dss_.filters_), np.abs(reference.filters_), atol=1e-12
+    )
+
+
+def test_sensor_patterns_equal_direct_training_least_squares():
+    """Sensor projection is explicit least squares, not a lag-pattern shortcut."""
+    data = _data(seed=31, offset=False)
+    fitted = _estimator().fit(data)
+    sources = fitted.transform(data).reshape(4, -1)
+    sensors = data[:, 1:, :].reshape(3, -1)
+    expected = sensors @ np.linalg.pinv(sources)
+
+    assert_allclose(fitted.patterns_, expected, rtol=1e-10, atol=1e-10)
+
+
+def test_centering_is_training_fitted_and_transform_batch_invariant():
+    """Unrelated transform epochs cannot change an unchanged source prefix."""
+    fit_data = _data(seed=1)
+    held_out = _data(seed=2, shape=(3, 80, 2))
+    unrelated = _data(seed=3, shape=(3, 80, 5)) * 20.0 + 100.0
+    est = _estimator(center=True).fit(fit_data)
+
+    prefix = est.transform(held_out)
+    combined = est.transform(np.concatenate([held_out, unrelated], axis=2))
+
+    assert_allclose(combined[:, :, :2], prefix, rtol=0.0, atol=1e-12)
+    assert not np.allclose(est.feature_mean_, 0.0)
+
+
+@pytest.mark.parametrize("center", [False, True])
+def test_full_rank_retain_reconstructs_valid_interval(center):
+    """Weighted least-squares patterns reconstruct the zero-lag sensor block."""
+    data = _data(shape=(3, 60, 8))
+    original = data.copy()
+    est = TimeShiftDSS(
+        lag_samples=[0, 1],
+        n_components=6,
+        rank=6,
+        n_select=6,
+        component_action="retain",
+        center=center,
+    )
+
+    retained = est.fit_transform(data)
+
+    assert_allclose(retained[:, 1:, :], data[:, 1:, :], rtol=1e-9, atol=1e-9)
+    assert_array_equal(retained[:, :1, :], data[:, :1, :])
+    assert_array_equal(data, original)
+
+
+def test_subtract_matches_selected_sensor_projection():
+    """Subtraction removes exactly the selected fitted component activity."""
+    data = _data()
+    est = _estimator(n_select=2, component_action="extract").fit(data)
+    sources = est.transform(data)
+    selected = est.patterns_[:, :2] @ sources[:2].reshape(2, -1)
+    selected = selected.reshape(3, 79, 8)
+
+    subtracted = est.set_params(component_action="subtract").transform(data)
+
+    assert_allclose(subtracted[:, 1:, :], data[:, 1:, :] - selected)
+    assert_array_equal(subtracted[:, 0, :], data[:, 0, :])
+
+
+def test_weight_broadcast_matches_explicit_time_epoch_matrix():
+    """One-dimensional time weights broadcast identically over epochs."""
+    data = _data(offset=False)
+    weights = np.linspace(0.2, 1.0, data.shape[1])
+    matrix = np.broadcast_to(weights[:, np.newaxis], data.shape[1:])
+
+    time_fit = _estimator().fit(data, sample_weight=weights)
+    matrix_fit = _estimator().fit(data, sample_weight=matrix)
+
+    assert_allclose(time_fit.eigenvalues_, matrix_fit.eigenvalues_)
+    assert_allclose(np.abs(time_fit.filters_), np.abs(matrix_fit.filters_))
+
+
+@pytest.mark.parametrize(
+    "weights, match",
+    [
+        (np.ones((8, 80)), "sample_weight"),
+        (np.full(80, np.nan), "finite"),
+        (np.r_[np.ones(79), -1.0], "non-negative"),
+        (np.zeros(80), "no positive-weight"),
+    ],
+)
+def test_invalid_sample_weights_are_rejected(weights, match):
+    """Fit weights have an explicit time-by-epoch contract."""
+    with pytest.raises(ValueError, match=match):
+        _estimator().fit(_data(), sample_weight=weights)
+
+
+def test_seconds_lags_resolve_against_sampling_grid():
+    """Physical lags become exact integer sample offsets."""
+    est = TimeShiftDSS(
+        lag_times=[0.0, 0.01],
+        sfreq=100.0,
+        n_components=4,
+        rank=4,
+    ).fit(_data())
+
+    assert est.lag_samples_ == (0, 1)
+    assert est.lag_times_ == (0.0, 0.01)
+
+    with pytest.raises(ValueError, match="sampling grid"):
+        TimeShiftDSS(
+            lag_times=[0.0, 0.015],
+            sfreq=100.0,
+            n_components=4,
+            rank=4,
+        ).fit(_data())
+    with pytest.raises(TypeError, match="booleans"):
+        TimeShiftDSS(
+            lag_times=[False, 0.01],
+            sfreq=100.0,
+            n_components=4,
+            rank=4,
+        ).fit(_data())
+
+
+def test_explicit_rank_and_selection_contracts():
+    """The estimator has no in-sample automatic component-selection path."""
+    data = _data()
+    with pytest.raises(ValueError, match="n_select is required"):
+        _estimator(component_action="retain").fit(data)
+    with pytest.raises(ValueError, match="cannot exceed rank"):
+        TimeShiftDSS(lag_samples=[0, 1], n_components=5, rank=4).fit(data)
+    with pytest.raises(ValueError, match="exceeds.*augmented"):
+        TimeShiftDSS(lag_samples=[0, 1], n_components=4, rank=7).fit(data)
+    assert not hasattr(_estimator(), "auto_select")
+
+
+def test_high_parameter_ratio_warns_instead_of_auto_selecting():
+    """A high-dimensional fit is visibly risky and never promotes components."""
+    data = _data(shape=(4, 14, 3), offset=False)
+    with pytest.warns(UserWarning, match="high risk of overfitting"):
+        est = TimeShiftDSS(
+            lag_samples=[0, 1, 2, 3, 4],
+            n_components=8,
+            rank=8,
+        ).fit(data)
+    rank_deficient = np.broadcast_to(data[:1], (3, *data.shape[1:])).copy()
+    with pytest.raises(ValueError, match="numerical whitening rank"):
+        _estimator(n_components=3, rank=4).fit(rank_deficient)
+
+    assert est.n_augmented_features_ == 20
+    assert not hasattr(est, "n_selected_")
+
+
+def test_cca_is_training_only_and_returns_one_component():
+    """CCA freezes its fitted rotation and produces one canonical variate."""
+    fit_data = _data(seed=10)
+    held_out = _data(seed=11, shape=(3, 80, 2))
+    unrelated = _data(seed=12, shape=(3, 80, 3)) * 30.0
+    est = _estimator(distortion_control="cca").fit(fit_data)
+
+    prefix = est.transform(held_out)
+    combined = est.transform(np.concatenate([held_out, unrelated], axis=2))
+
+    assert prefix.shape == (1, 79, 2)
+    assert est.cca_rotation_.shape == (1, 4)
+    assert est.filters_.shape == (1, 6)
+    assert est.dss_.filters_.shape == (4, 6)
+    assert est.patterns_.shape == (3, 1)
+    assert 0 <= est.cca_correlations_[0] <= 1
+    assert_allclose(combined[:, :, :2], prefix, rtol=0.0, atol=1e-12)
+
+
+def test_score_uses_a_fixed_leading_subspace_on_held_out_trials():
+    """Evaluation returns one finite score for the declared leading subspace."""
+    fit_data = _data(seed=20)
+    held_out = _data(seed=21, shape=(3, 80, 4))
+    est = _estimator(n_select=2).fit(fit_data)
+
+    score = est.score(held_out)
+
+    assert np.isfinite(score)
+    assert score >= 0
+
+
+def test_score_accepts_a_different_epoch_length():
+    """Held-out scoring derives lag support from the evaluated data."""
+    fit_data = _data(seed=22, shape=(3, 80, 8))
+    held_out = _data(seed=23, shape=(3, 50, 4))
+    est = _estimator(n_select=2).fit(fit_data)
+
+    score = est.score(held_out)
+
+    assert np.isfinite(score)
+
+
+def test_score_requires_a_predeclared_subspace():
+    """Validation never chooses a component count from held-out observations."""
+    est = _estimator().fit(_data(seed=24))
+
+    with pytest.raises(ValueError, match="explicit n_select"):
+        est.score(_data(seed=25, shape=(3, 80, 4)))
+
+
+def test_mne_epochs_preserve_metadata_and_bad_channels():
+    """Sensor output uses shared reconstruction and leaves excluded bads unchanged."""
+    data = np.transpose(_data(shape=(4, 80, 8)), (2, 0, 1)) * 1e-6
+    info = mne.create_info(["EEG0", "EEG1", "EEG2", "EEG3"], 100.0, "eeg")
+    epochs = mne.EpochsArray(data, info, tmin=-0.2, verbose=False)
+    epochs.info["bads"] = ["EEG3"]
+    events = epochs.events.copy()
+    metadata = epochs.metadata
+    est = TimeShiftDSS(
+        lag_times=[0.0, 0.01],
+        n_components=4,
+        rank=4,
+        n_select=1,
+        component_action="subtract",
+    )
+
+    cleaned = est.fit_transform(epochs)
+
+    assert isinstance(cleaned, mne.BaseEpochs)
+    assert_array_equal(cleaned.events, events)
+    assert cleaned.metadata is metadata
+    assert cleaned.tmin == epochs.tmin
+    assert cleaned.info["bads"] == epochs.info["bads"]
+    assert_array_equal(
+        cleaned.get_data(picks=["EEG3"]), epochs.get_data(picks=["EEG3"])
+    )
+
+
+def test_array_integer_input_produces_float_without_mutation():
+    """Integer observations cannot truncate fitted or reconstructed values."""
+    data = np.rint(_data() * 4).astype(np.int64)
+    original = data.copy()
+    out = _estimator(n_select=1, component_action="subtract").fit_transform(data)
+
+    assert out.dtype == np.float64
+    assert_array_equal(data, original)
+
+
+def test_estimator_is_cloneable():
+    """All scientific choices remain explicit sklearn parameters."""
+    estimator = _estimator(center=True, distortion_control="cca")
+    cloned = clone(estimator)
+
+    assert cloned.get_params() == estimator.get_params()

--- a/tests/variants/test_tsr.py
+++ b/tests/variants/test_tsr.py
@@ -156,6 +156,63 @@ def test_lag_augmentation_sign_and_epoch_isolation():
     assert_array_equal(augmented[2], [[0.0, 100.0], [1.0, 101.0]])
 
 
+@pytest.mark.parametrize(
+    "lag_kws, error, match",
+    [
+        ({}, ValueError, "exactly one"),
+        (
+            {"lag_samples": [0, 1], "lag_times": [0.0, 0.01], "sfreq": 100.0},
+            ValueError,
+            "exactly one",
+        ),
+        ({"lag_samples": "0,1"}, TypeError, "one-dimensional sequence"),
+        ({"lag_samples": []}, ValueError, "non-empty"),
+        ({"lag_samples": [0, True]}, TypeError, "only integers"),
+        ({"lag_samples": [1, 2]}, ValueError, "contain zero"),
+        (
+            {"lag_times": "0,0.01", "sfreq": 100.0},
+            TypeError,
+            "one-dimensional sequence",
+        ),
+        (
+            {"lag_times": [0.0, np.nan], "sfreq": 100.0},
+            ValueError,
+            "finite",
+        ),
+    ],
+)
+def test_invalid_lag_declarations(lag_kws, error, match):
+    """Lag declarations reject ambiguous, malformed, and non-finite grids."""
+    with pytest.raises(error, match=match):
+        TimeShiftDSS(n_components=1, rank=1, **lag_kws).fit(_data())
+
+
+@pytest.mark.parametrize(
+    "data, match",
+    [
+        (np.ones((3, 20)), "requires epoched data"),
+        (np.empty((0, 20, 2)), "dimensions must be non-empty"),
+        (np.ones((3, 1, 2)), "dimensions must be non-empty"),
+        (np.ones((3, 20, 1)), "at least two repeated epochs"),
+        (np.full((3, 20, 2), np.nan), "finite values"),
+    ],
+)
+def test_invalid_epoched_array_geometry(data, match):
+    """The repeated-trial array contract is checked before decomposition."""
+    with pytest.raises(ValueError, match=match):
+        _estimator().fit(data)
+
+
+def test_lag_span_must_leave_two_common_samples():
+    """Lag grids cannot consume the complete within-epoch support."""
+    with pytest.raises(ValueError, match="fewer than two common"):
+        TimeShiftDSS(
+            lag_samples=[0, 19],
+            n_components=1,
+            rank=1,
+        ).fit(_data(shape=(3, 20, 2)))
+
+
 def test_lag_weights_use_minimum_across_touched_samples():
     """A zero-weight source sample invalidates every lag window touching it."""
     weights = np.ones((6, 2))
@@ -342,7 +399,31 @@ def test_explicit_rank_and_selection_contracts():
         TimeShiftDSS(lag_samples=[0, 1], n_components=5, rank=4).fit(data)
     with pytest.raises(ValueError, match="exceeds.*augmented"):
         TimeShiftDSS(lag_samples=[0, 1], n_components=4, rank=7).fit(data)
+    with pytest.raises(ValueError, match="n_select cannot exceed"):
+        _estimator(n_select=5).fit(data)
     assert not hasattr(_estimator(), "auto_select")
+
+
+@pytest.mark.parametrize(
+    "kwargs, error, match",
+    [
+        ({"component_action": "invalid"}, ValueError, "component_action"),
+        ({"center": 1}, TypeError, "center"),
+        ({"distortion_control": "invalid"}, ValueError, "distortion_control"),
+        (
+            {"distortion_control": "cca", "n_select": 2},
+            ValueError,
+            "CCA distortion control",
+        ),
+        ({"reg": True}, TypeError, "reg"),
+        ({"reg": 0.0}, ValueError, "reg"),
+        ({"reg": np.nan}, ValueError, "reg"),
+    ],
+)
+def test_invalid_estimator_parameters(kwargs, error, match):
+    """Constructor choices fail explicitly before fitting numerical state."""
+    with pytest.raises(error, match=match):
+        _estimator(**kwargs).fit(_data())
 
 
 def test_high_parameter_ratio_warns_instead_of_auto_selecting():
@@ -410,6 +491,60 @@ def test_score_requires_a_predeclared_subspace():
 
     with pytest.raises(ValueError, match="explicit n_select"):
         est.score(_data(seed=25, shape=(3, 80, 4)))
+
+
+def test_score_returns_zero_for_zero_power_held_out_data():
+    """A valid held-out set with no component power has a finite zero score."""
+    est = _estimator(n_select=2).fit(_data(seed=26))
+
+    assert est.score(np.zeros((3, 80, 4))) == 0.0
+
+
+def test_transform_rejects_container_and_channel_contract_changes():
+    """A fitted estimator freezes both input family and channel geometry."""
+    est = _estimator().fit(_data())
+    info = mne.create_info(3, 100.0, "eeg")
+    epochs = mne.EpochsArray(
+        np.transpose(_data(shape=(3, 80, 2)), (2, 0, 1)),
+        info,
+        verbose=False,
+    )
+
+    with pytest.raises(TypeError, match="container family"):
+        est.transform(epochs)
+    with pytest.raises(TypeError, match="supports MNE Epochs or NumPy arrays"):
+        est.transform([[[1.0]]])
+    with pytest.raises(ValueError, match="channels; fitted data had"):
+        est.transform(_data(shape=(4, 80, 2)))
+
+
+def test_mne_epochs_extract_returns_epoch_major_sources():
+    """MNE extraction returns an array in epochs-by-components orientation."""
+    data = np.transpose(_data(shape=(3, 40, 5)), (2, 0, 1)) * 1e-6
+    epochs = mne.EpochsArray(
+        data,
+        mne.create_info(3, 100.0, "eeg"),
+        verbose=False,
+    )
+
+    sources = _estimator().fit_transform(epochs)
+
+    assert isinstance(sources, np.ndarray)
+    assert sources.shape == (5, 4, 39)
+
+
+def test_empty_cca_solution_is_rejected(monkeypatch):
+    """CCA distortion control rejects a numerically empty canonical space."""
+
+    def _empty_cca(*args, **kwargs):
+        return None, None, np.array([]), None, None
+
+    monkeypatch.setattr(
+        "mne_denoise.dss.variants.tsr.canonical_correlation",
+        _empty_cca,
+    )
+    with pytest.raises(ValueError, match="CCA input has no variance"):
+        _estimator(distortion_control="cca").fit(_data())
 
 
 def test_mne_epochs_preserve_metadata_and_bad_channels():


### PR DESCRIPTION
  - Add TimeShiftDSS as lag-augmented repeated-trial DSS built on the shared DSS estimator.
  - Support explicit lag, rank, selection, weighting, centering, reconstruction, scoring, and optional CCA contracts.
  - Fix time-by-epoch covariance and AverageBias weight ordering.
  - Make DSS transforms reuse their fitted global mean.
  - Share weighted CCA, sensor-mixing, and positive-integer validation helpers.
  - Rename TimeShiftBias to LagAverageBias and remove the ambiguous time_shift_dss() constructor.
  - Keep package behavior tests in test_tsr.py and scientific parity/null checks in the validation script.
  - Update the public API, documentation, temporal DSS example, and changelog.

A clean implementation of tsDSS, inheriting some functions of the #61 #57.