### PR TITLE
feat(dss): add validated cardiac artifact composition

### DIFF
--- a/docs/changes/devel/71.bugfix.rst
+++ b/docs/changes/devel/71.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed ``CycleAverageBias`` so epochs cannot share windows, overlaps are
+event-order invariant, integer averages cannot truncate, and event coordinates,
+boundaries, origins, duplicates, and minimum counts have explicit contracts.

--- a/docs/changes/devel/71.feature.rst
+++ b/docs/changes/devel/71.feature.rst
@@ -1,0 +1,2 @@
+Added an explicit cardiac-cleaning composition from MNE ECG detection,
+``CycleAverageBias``, and subtractive ``DSS``, with a held-out gallery example.

--- a/docs/changes/devel/71.misc.rst
+++ b/docs/changes/devel/71.misc.rst
@@ -1,0 +1,3 @@
+Added deterministic cardiac DSS scientific validation with isolated-source
+metrics, negative controls, sensitivity sweeps, resampling, and optional ECG SSP
+comparison on a local recording.

--- a/docs/dss.md
+++ b/docs/dss.md
@@ -125,21 +125,96 @@ print(f"Power reduction: {est.n_removed_} components")
 | `TrialAverageBias` | Evoked responses     | Epoch averaging for phase-locked signals |
 | `BandpassBias`     | Rhythm extraction    | Narrow-band filter for oscillations      |
 | `NotchBias`        | Line noise isolation | Isolate specific frequency               |
-| `CycleAverageBias` | Artifact removal     | Cycle-locked averaging for ECG/blinks    |
+| `CycleAverageBias` | Event-locked contrast | Fixed-window averaging for ECG/blinks    |
 
 Example usage:
 
 ```python
-from mne_denoise.dss import TrialAverageBias, CycleAverageBias
+from mne_denoise.dss import AverageBias, CycleAverageBias
 
 # Evoked response enhancement
 epochs_data = np.random.randn(64, 200, 100)  # channels x times x epochs
-bias = TrialAverageBias()
+bias = AverageBias(axis="epochs")
 
 # ECG artifact removal
 r_peaks = find_r_peaks(ecg_signal)
-bias = CycleAverageBias(event_samples=r_peaks, window=(-0.1, 0.3), sfreq=500)
+bias = CycleAverageBias(
+    event_samples=r_peaks,
+    window=(-0.1, 0.3),
+    window_unit="seconds",
+    sfreq=500,
+    event_origin="data",
+)
 ```
+
+`CycleAverageBias` uses the half-open interval
+`[event + start, event + stop)`. It deduplicates coordinates, averages
+overlapping reconstructions commutatively, rejects incomplete windows, and
+requires at least two unique events. For channel-first epoched input, events
+must be explicit `(epoch_index, sample_index)` pairs; flat indices never join
+independent epochs. Two events are only the mathematical minimum. Practical
+cardiac estimates generally need many representative beats.
+
+This operation is a fixed-window package extension. It is not the complete
+quasiperiodic algorithm in Särelä and Valpola (2005), which detects
+peak-to-peak periods, maps variable periods to a common length, maps the
+average back to each period, and iteratively re-estimates QRS events in the
+cardiac application.
+
+### Cardiac cleaning by composition
+
+Cardiac DSS is expressed using the public event detector, bias, and canonical
+`DSS` estimator rather than a separate wrapper:
+
+```python
+from mne.preprocessing import find_ecg_events
+from mne_denoise.dss import CycleAverageBias, DSS
+
+train_events, _, _ = find_ecg_events(train_raw, ch_name="ECG")
+train_data = train_raw.copy().pick("eeg")
+held_out_data = held_out_raw.copy().pick("eeg")
+
+bias = CycleAverageBias(
+    event_samples=train_events[:, 0],
+    window=(-0.15, 0.25),
+    window_unit="seconds",
+    sfreq=train_data.info["sfreq"],
+    event_origin="raw",
+    first_samp=train_data.first_samp,
+)
+cleaner = DSS(
+    bias=bias,
+    rank={"eeg": 32},
+    n_components=10,
+    n_select=1,
+    component_action="subtract",
+)
+cleaner.fit(train_data)
+held_out_clean = cleaner.transform(held_out_data)
+```
+
+The bias and ECG events are used during fitting only; `transform()` applies a
+frozen spatial operator. Quantify QRS-locked attenuation and neural
+preservation on held-out data before accepting subtraction. A reproducible
+cardiac-locked component can contain neural signal as well as artifact, so
+`n_select=1` above is an explicit scientific choice, not an automatic safety
+guarantee. See the cardiac composition gallery example for executable metrics.
+
+The standalone validation can be run with:
+
+```bash
+python scripts/validate_cardiac_dss.py --output cardiac_dss_validation.json
+```
+
+For its deterministic synthetic positive control, the current run reports
+22.74 dB isolated cardiac RMS attenuation, 99.87% target-neural retained
+power, 0.999998 target waveform correlation, and 20.93 dB held-out SNR
+improvement. These figures establish behavior for that declared simulation,
+not superiority or clinical validity. The JSON also records shuffled,
+time-reversed, circularly shifted, pure-noise, neural-only, wrong-origin,
+resampling, and parameter-sensitivity controls. An optional local FIF pathway
+compares unchanged data, the composition, and MNE ECG SSP on one recording;
+one recording demonstrates plausibility and failure modes only.
 
 ### Nonlinear Biases
 

--- a/examples/dss/README.rst
+++ b/examples/dss/README.rst
@@ -22,6 +22,7 @@ Files
 - ``plot_10_benchmarking.py``: Efficiency benchmarking against PCA, ICA, and averaging.
 - ``plot_11_wiener_masking.py``: Adaptive Wiener masking for bursty signals.
 - ``plot_12_joint_dss.py``: Joint DSS for multi-dataset repeatability.
+- ``plot_13_cardiac_composition.py``: Explicit, held-out cardiac DSS composition with attenuation and preservation checks.
 
 Data Requirements
 -----------------

--- a/examples/dss/plot_02_artifact_correction.py
+++ b/examples/dss/plot_02_artifact_correction.py
@@ -210,7 +210,13 @@ print(f"Found {len(blink_samples)} blink events")
 # Create CycleAverageBias
 # Window: 100ms before to 100ms after each blink (in samples)
 window_samples = (-int(0.1 * raw.info["sfreq"]), int(0.1 * raw.info["sfreq"]))
-bias_cycle = CycleAverageBias(event_samples=blink_samples, window=window_samples)
+bias_cycle = CycleAverageBias(
+    event_samples=blink_samples,
+    window=window_samples,
+    window_unit="samples",
+    event_origin="raw",
+    first_samp=raw_meg.first_samp,
+)
 
 # Fit DSS on continuous MEG data
 dss_cycle = DSS(
@@ -261,8 +267,8 @@ plot_component_patterns(
 plt.gcf().suptitle("CycleAverageBias: Blink Component Topography")
 plt.show()
 
-print("\nBoth approaches extract the same blink artifact!")
-print("- TrialAverageBias: Works on MNE Epochs (easier integration)")
+print("\nBoth approaches can emphasize a reproducible blink-locked pattern.")
+print("- AverageBias(axis='epochs'): Works on MNE Epochs (easier integration)")
 print("- CycleAverageBias: Works on continuous data + event samples (more direct)")
 
 # %%

--- a/examples/dss/plot_13_cardiac_composition.py
+++ b/examples/dss/plot_13_cardiac_composition.py
@@ -1,0 +1,202 @@
+"""
+Cardiac DSS as an Explicit Composition
+======================================
+
+This example keeps cardiac cleaning visible as three public operations:
+
+1. detect QRS events with MNE;
+2. define a fixed-window :class:`~mne_denoise.dss.CycleAverageBias`; and
+3. fit :class:`~mne_denoise.dss.DSS` with ``component_action="subtract"``.
+
+The synthetic recording supplies isolated neural ground truth so attenuation
+and preservation can both be checked on held-out data. A reproducible
+cardiac-locked component can contain neural signal as well as artifact, so the
+choice to subtract one component below is a scientific decision, not an
+automatic guarantee of safe cleaning.
+"""
+
+# Authors: mne-denoise developers
+
+from __future__ import annotations
+
+import mne
+import numpy as np
+from mne.preprocessing import find_ecg_events
+
+from mne_denoise.dss import DSS, CycleAverageBias
+from mne_denoise.viz import (
+    plot_channel_time_course_comparison,
+    plot_evoked_gfp_comparison,
+)
+
+
+def _event_locked_average(data, event_samples, first_samp, window):
+    """Return the sensor average in one half-open QRS window."""
+    events = np.asarray(event_samples, dtype=int) - int(first_samp)
+    start, stop = window
+    return np.mean(
+        np.stack([data[:, event + start : event + stop] for event in events]),
+        axis=0,
+    )
+
+
+# %%
+# Make a deterministic MNE recording
+# ----------------------------------
+# The neural ground truth includes alpha activity and a slow oscillation at the
+# 1.25 Hz heart rate. The latter deliberately overlaps the cardiac spectrum.
+
+rng = np.random.default_rng(18)
+sfreq = 200.0
+duration = 60.0
+n_times = int(sfreq * duration)
+times = np.arange(n_times) / sfreq
+first_samp = 1_000
+n_eeg = 6
+
+neural_sources = np.vstack(
+    [
+        np.sin(2 * np.pi * 10.0 * times),
+        0.7 * np.sin(2 * np.pi * 1.25 * times + 0.4),
+        0.4 * np.sin(2 * np.pi * 18.0 * times + 1.1),
+    ]
+)
+neural_topographies = rng.normal(size=(n_eeg, len(neural_sources)))
+neural = neural_topographies @ neural_sources
+neural /= np.std(neural)
+
+qrs_samples = np.arange(int(sfreq), n_times - int(sfreq), int(0.8 * sfreq))
+qrs_times = np.arange(-20, 31)
+qrs_shape = np.exp(-0.5 * (qrs_times / 3.0) ** 2)
+qrs_shape -= 0.35 * np.exp(-0.5 * ((qrs_times - 8) / 5.0) ** 2)
+ecg = np.zeros(n_times)
+for sample in qrs_samples:
+    ecg[sample - 20 : sample + 31] += qrs_shape
+
+cardiac_topography = np.array([20.0, 14.0, -10.0, 7.0, -5.0, 3.0])
+cardiac = np.outer(cardiac_topography, ecg)
+background = 0.08 * rng.standard_normal((n_eeg, n_times))
+mixture = neural + cardiac + background
+
+ch_names = [f"EEG {index:03d}" for index in range(1, n_eeg + 1)] + ["ECG"]
+info = mne.create_info(ch_names, sfreq, ["eeg"] * n_eeg + ["ecg"])
+raw = mne.io.RawArray(
+    np.vstack([mixture, ecg + 0.01 * rng.standard_normal(n_times)]),
+    info,
+    first_samp=first_samp,
+    verbose=False,
+)
+
+# %%
+# Detect events, split, and fit only on training data
+# ---------------------------------------------------
+# ``find_ecg_events`` returns acquisition-numbered event samples. Cropping an
+# MNE Raw changes ``first_samp``, so each bias declares that origin explicitly.
+
+train = raw.copy().crop(tmin=0.0, tmax=29.995)
+held_out = raw.copy().crop(tmin=30.0, tmax=59.995)
+train_events, _, _ = find_ecg_events(train, ch_name="ECG", verbose=False)
+held_out_events, _, _ = find_ecg_events(held_out, ch_name="ECG", verbose=False)
+train_eeg = train.copy().pick("eeg")
+held_out_eeg = held_out.copy().pick("eeg")
+
+window_seconds = (-0.15, 0.25)
+window_samples = tuple(round(value * sfreq) for value in window_seconds)
+bias = CycleAverageBias(
+    event_samples=train_events[:, 0],
+    window=window_seconds,
+    window_unit="seconds",
+    sfreq=sfreq,
+    event_origin="raw",
+    first_samp=train_eeg.first_samp,
+)
+cardiac_dss = DSS(
+    bias=bias,
+    rank=n_eeg,
+    n_components=4,
+    n_select=1,
+    component_action="subtract",
+    normalize_input=False,
+)
+cardiac_dss.fit(train_eeg)
+cleaned = cardiac_dss.transform(held_out_eeg)
+
+# %%
+# Require attenuation and preservation together
+# ---------------------------------------------
+# The event bias is used only during ``fit``. ``transform`` is a frozen spatial
+# operator and does not inspect the held-out event times. Those events are used
+# below only to evaluate QRS-locked attenuation.
+
+before_locked = _event_locked_average(
+    held_out_eeg.get_data(),
+    held_out_events[:, 0],
+    held_out_eeg.first_samp,
+    window_samples,
+)
+after_locked = _event_locked_average(
+    cleaned.get_data(),
+    held_out_events[:, 0],
+    cleaned.first_samp,
+    window_samples,
+)
+attenuation_db = 20 * np.log10(
+    np.sqrt(np.mean(before_locked**2)) / np.sqrt(np.mean(after_locked**2))
+)
+
+held_slice = slice(int(30 * sfreq), n_times)
+neural_info = mne.create_info(ch_names[:-1], sfreq, ["eeg"] * n_eeg)
+neural_held_out = mne.io.RawArray(
+    neural[:, held_slice],
+    neural_info,
+    first_samp=held_out_eeg.first_samp,
+    verbose=False,
+)
+neural_after = cardiac_dss.transform(neural_held_out).get_data()
+neural_before = neural_held_out.get_data()
+retained_power = np.sum(neural_after**2) / np.sum(neural_before**2)
+waveform_correlation = np.corrcoef(neural_before.ravel(), neural_after.ravel())[0, 1]
+
+print(f"Held-out QRS-locked RMS attenuation: {attenuation_db:.2f} dB")
+print(f"Held-out neural retained power: {100 * retained_power:.1f}%")
+print(f"Held-out neural waveform correlation: {waveform_correlation:.4f}")
+
+# These illustrative gates require artifact attenuation and neural preservation
+# simultaneously. They are not universal acceptance criteria for real studies.
+passes_example_gates = (
+    attenuation_db >= 6.0 and retained_power >= 0.8 and waveform_correlation >= 0.95
+)
+print(f"Passes the predeclared illustrative gates: {passes_example_gates}")
+
+# %%
+# Inspect the held-out event-locked result
+# ----------------------------------------
+
+locked_times = np.arange(window_samples[0], window_samples[1]) / sfreq
+plot_evoked_gfp_comparison(
+    before_locked,
+    after_locked,
+    times=locked_times,
+    ci=None,
+    labels=("Unchanged", "Frozen DSS subtraction"),
+    x_label="Time from QRS (s)",
+    y_label="Sensor RMS (a.u.)",
+    title="Held-out QRS-locked global field power",
+    show=True,
+)
+
+# %%
+# Individual sensor traces make it possible to see whether attenuation is
+# spatially concentrated or indiscriminate. This uses the same package-level
+# before/after visualization API as the other denoising examples.
+
+plot_channel_time_course_comparison(
+    before_locked,
+    after_locked,
+    picks=range(min(3, n_eeg)),
+    times=locked_times,
+    before_label="Unchanged",
+    after_label="Frozen DSS subtraction",
+    x_label="Time from QRS (s)",
+    show=True,
+)

--- a/mne_denoise/_validation.py
+++ b/mne_denoise/_validation.py
@@ -7,6 +7,7 @@ consistent across the package.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from numbers import Integral, Real
 
 import numpy as np
@@ -104,6 +105,81 @@ def check_sfreq(sfreq: float | None, *, context: str | None = None) -> float:
     if not np.isfinite(sfreq) or sfreq <= 0:
         raise ValueError("sfreq must be a positive, finite number")
     return sfreq
+
+
+def resolve_sample_window(
+    window: Sequence[int | float],
+    *,
+    unit: str,
+    sfreq: float | None = None,
+    name: str = "window",
+) -> tuple[int, int]:
+    """Validate a half-open time window and resolve it to sample offsets.
+
+    Parameters
+    ----------
+    window : sequence of int or float
+        Ordered ``(start, stop)`` boundaries.
+    unit : {"samples", "seconds"}
+        Unit of the supplied boundaries. Sample-valued boundaries must be
+        integers. Second-valued boundaries use nearest-sample rounding with
+        ties to even.
+    sfreq : float | None, default=None
+        Sampling frequency. Required for second-valued windows and validated
+        when supplied for sample-valued windows.
+    name : str, default="window"
+        Parameter name used in error messages.
+
+    Returns
+    -------
+    sample_window : tuple of int
+        Nonempty half-open ``(start, stop)`` sample offsets.
+    """
+    if unit not in {"samples", "seconds"}:
+        raise ValueError(f"{name}_unit must be 'samples' or 'seconds', got {unit!r}.")
+
+    values = np.asarray(window, dtype=object)
+    if values.shape != (2,):
+        raise ValueError(f"{name} must contain exactly two numeric boundaries.")
+    normalized = []
+    for value in values.tolist():
+        if isinstance(value, bool) or not isinstance(value, Real):
+            raise ValueError(f"{name} must contain exactly two numeric boundaries.")
+        if isinstance(value, Integral):
+            normalized.append(int(value))
+            continue
+        if not np.isfinite(float(value)):
+            raise ValueError(f"{name} boundaries must be finite.")
+        normalized.append(float(value))
+    if normalized[0] >= normalized[1]:
+        raise ValueError(f"{name} start must be strictly less than {name} stop.")
+
+    if unit == "samples":
+        if any(not isinstance(value, Integral) for value in normalized):
+            raise ValueError(
+                f"{name} boundaries must be integers when {name}_unit='samples'."
+            )
+        if sfreq is not None:
+            check_sfreq(sfreq)
+        resolved = [int(value) for value in normalized]
+    else:
+        sfreq = check_sfreq(sfreq, context=f"{name}_unit='seconds'")
+        scaled = [float(value) * sfreq for value in normalized]
+        if not np.all(np.isfinite(scaled)):
+            raise ValueError(
+                f"{name} boundaries in seconds resolve outside the finite sample range."
+            )
+        resolved = [round(value) for value in scaled]
+
+    bounds = np.iinfo(np.int64)
+    if any(value < int(bounds.min) or value > int(bounds.max) for value in resolved):
+        raise ValueError(f"{name} boundaries must fit in signed 64-bit samples.")
+    if resolved[0] >= resolved[1]:
+        raise ValueError(
+            f"{name} resolves to an empty or reversed sample interval; "
+            "increase its duration or sfreq."
+        )
+    return int(resolved[0]), int(resolved[1])
 
 
 def check_chunk_size(chunk_size: int | None) -> int | None:

--- a/mne_denoise/dss/denoisers/artifact.py
+++ b/mne_denoise/dss/denoisers/artifact.py
@@ -1,146 +1,291 @@
-"""Artifact-based bias functions for DSS.
-
-Implements cycle averaging for quasi-periodic artifacts like ECG and blinks.
-This emphasizes reproducible artifact morphology while canceling neural activity.
+"""Event-locked fixed-window bias functions for DSS.
 
 Authors: Sina Esmaeili (sina.esmaeili@umontreal.ca)
          Hamza Abdelhedi (hamza.abdelhedi@umontreal.ca)
-
-References
-----------
-.. [1] Särelä & Valpola (2005). Denoising Source Separation. J. Mach. Learn. Res., 6, 233-272.
 """
 
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Literal
 
 import numpy as np
 
+from ..._validation import (
+    check_positive_integer,
+    check_sfreq,
+    resolve_sample_window,
+)
 from .base import LinearDenoiser
 
 
-class CycleAverageBias(LinearDenoiser):
-    """Bias for removing quasi-periodic artifacts (e.g., ECG, EOG).
+def _as_int64_coordinates(
+    values: object, name: str, *, ndim: tuple[int, ...]
+) -> np.ndarray:
+    """Return exact integer coordinates without signed overflow."""
+    array = np.asarray(values, dtype=object)
+    if array.ndim not in ndim:
+        dimensions = " or ".join(f"{value}-D" for value in ndim)
+        raise ValueError(f"{name} must be a {dimensions} integer array.")
+    if array.ndim == 2 and array.shape[1] != 2:
+        raise ValueError(
+            f"{name} must have shape (n_events, 2) for per-epoch coordinates."
+        )
 
-    Applies cycle averaging synchronized to artifact events (e.g., R-peaks
-    for ECG, blink onsets for EOG). This emphasizes the stereotyped
-    artifact waveform while canceling non-phase-locked neural activity.
+    bounds = np.iinfo(np.int64)
+    converted = []
+    for value in array.ravel().tolist():
+        if isinstance(value, (bool, np.bool_)) or not isinstance(
+            value, (int, np.integer)
+        ):
+            raise ValueError(f"{name} must contain only integer coordinates.")
+        integer = int(value)
+        if integer < int(bounds.min) or integer > int(bounds.max):
+            raise ValueError(f"{name} values must fit in signed 64-bit samples.")
+        converted.append(integer)
+    return np.asarray(converted, dtype=np.int64).reshape(array.shape)
+
+
+def _prepare_events(
+    event_samples: object, event_origin: str, first_samp: int | None
+) -> tuple[np.ndarray, int | None, np.ndarray]:
+    """Validate, deduplicate, and map public event coordinates."""
+    if event_origin not in {"data", "raw"}:
+        raise ValueError(f"event_origin must be 'data' or 'raw', got {event_origin!r}.")
+    if event_origin == "raw" and first_samp is None:
+        raise ValueError("first_samp is required when event_origin='raw'.")
+    if event_origin == "data" and first_samp is not None:
+        raise ValueError(
+            "first_samp must be omitted when event_origin='data'; events are "
+            "already relative to the supplied data."
+        )
+
+    events = np.unique(
+        _as_int64_coordinates(event_samples, "event_samples", ndim=(1, 2)), axis=0
+    )
+    if events.ndim == 2:
+        if np.any(events[:, 0] < 0):
+            raise ValueError("epoch indices in event_samples must be non-negative.")
+        if event_origin == "raw":
+            raise ValueError(
+                "event_origin='raw' is not defined for per-epoch coordinates; "
+                "use data-relative (epoch_index, sample_index) pairs."
+            )
+        return events, None, events.copy()
+
+    if first_samp is None:
+        return events, None, events.copy()
+    first_samp = int(_as_int64_coordinates([first_samp], "first_samp", ndim=(1,))[0])
+    mapped = _as_int64_coordinates(
+        [int(event) - first_samp for event in events],
+        "event_samples after applying first_samp",
+        ndim=(1,),
+    )
+    return events, first_samp, mapped
+
+
+def _as_float_data(data: np.ndarray) -> np.ndarray:
+    """Validate numerical input and convert it without mutating the caller."""
+    array = np.asarray(data)
+    if array.ndim not in (2, 3):
+        raise ValueError(f"Data must be 2D or 3D, got {array.ndim}D.")
+    if not np.issubdtype(array.dtype, np.number):
+        raise TypeError("Data must contain real numerical values.")
+    if np.iscomplexobj(array):
+        raise TypeError("Data must be real-valued, not complex.")
+    if not np.all(np.isfinite(array)):
+        raise ValueError("Data must contain only finite values.")
+    dtype = np.float32 if array.dtype == np.float32 else np.float64
+    return np.asarray(array, dtype=dtype)
+
+
+def _event_segments(
+    data: np.ndarray,
+    events: np.ndarray,
+    window: tuple[int, int],
+    min_events: int,
+) -> list[tuple[slice, ...]]:
+    """Validate coordinates and return safe indexing segments."""
+    if data.ndim == 2 and events.ndim != 1:
+        raise ValueError("2-D data requires one-dimensional event sample coordinates.")
+    if data.ndim == 3 and events.ndim != 2:
+        raise ValueError(
+            "3-D data requires (epoch_index, sample_index) event coordinates; "
+            "flat global sample indices are not accepted."
+        )
+    if len(events) < min_events:
+        raise ValueError(
+            f"CycleAverageBias requires at least {min_events} unique complete "
+            f"events; received {len(events)} after deduplication."
+        )
+
+    n_times = data.shape[1]
+    n_epochs = None if data.ndim == 2 else data.shape[2]
+    pre, post = window
+    segments = []
+    for coordinate in events.tolist():
+        if events.ndim == 1:
+            sample = int(coordinate)
+            label = f"event sample {sample}"
+            segment = (slice(sample + pre, sample + post),)
+        else:
+            epoch, sample = (int(value) for value in coordinate)
+            label = f"event ({epoch}, {sample})"
+            assert n_epochs is not None
+            if epoch >= n_epochs:
+                raise ValueError(
+                    f"{label} is out of range for data with {n_epochs} epochs."
+                )
+            segment = (slice(sample + pre, sample + post), epoch)
+        if sample < 0 or sample >= n_times:
+            raise ValueError(
+                f"{label} is out of range for the sample coordinates [0, {n_times})."
+            )
+        if sample + pre < 0 or sample + post > n_times:
+            raise ValueError(
+                f"{label} with half-open window [{sample + pre}, {sample + post}) "
+                f"crosses the data boundary [0, {n_times}); adjust events or window."
+            )
+        segments.append(segment)
+    return segments
+
+
+class CycleAverageBias(LinearDenoiser):
+    """Fixed-window event-locked averaging bias.
+
+    The operation estimates one average window from the supplied events and
+    places that average at every event. Samples outside event windows are zero.
+    When windows overlap, their contributions are averaged, so the result is
+    independent of event order. Duplicate coordinates are removed before the
+    average is estimated.
+
+    This is a useful fixed-window extension for stereotyped events such as ECG
+    QRS complexes or blinks. It is not the complete quasiperiodic method of
+    Särelä and Valpola (2005): that method estimates variable peak-to-peak
+    periods, warps them to a common duration, and iteratively updates QRS events
+    in its cardiac application.
 
     Parameters
     ----------
-    event_samples : array-like
-        Sample indices of artifact events (e.g., R-peak locations).
-    window : tuple of int
-        (pre, post) samples around each event to include.
-        Default (-100, 200) for ~300ms window at 1kHz.
-    sfreq : float, optional
-        Sampling frequency for window specification in seconds.
-        If provided, window can be in seconds instead of samples.
+    event_samples : array-like of int, shape (n_events,) or (n_events, 2)
+        Event coordinates. One-dimensional coordinates apply only to 2-D data
+        and use ``event_origin``. For 3-D channel-first data, coordinates must
+        be ``(epoch_index, sample_index)`` pairs; both values are zero-based and
+        relative to the supplied epoched array. Flat global sample indices are
+        rejected for 3-D data.
+    window : tuple of int or float
+        Half-open interval ``[event + start, event + stop)``. The resolved
+        interval must be complete for every event; boundary-crossing and
+        out-of-range coordinates raise an error rather than being discarded.
+    window_unit : {"samples", "seconds"}, default="samples"
+        Unit of ``window``. Sample boundaries must be integers. Second-valued
+        boundaries are converted using nearest-sample rounding (ties to even).
+    sfreq : float | None, default=None
+        Sampling frequency in Hz. Required for ``window_unit="seconds"``.
+    event_origin : {"data", "raw"}, default="data"
+        Origin of one-dimensional event coordinates. ``"data"`` means sample
+        zero is the first sample passed to :meth:`apply`. ``"raw"`` means MNE
+        acquisition sample numbering and requires ``first_samp``. Per-epoch
+        coordinates always use the data-relative origin.
+    first_samp : int | None, default=None
+        First acquisition sample of the corresponding MNE Raw object. It is
+        subtracted exactly once when ``event_origin="raw"`` and is otherwise
+        forbidden.
+    min_events : int, default=2
+        Minimum number of unique, complete events. Values below two are not
+        allowed because one window has no across-event repeatability contrast.
+        Two is a mathematical minimum, not a practical recommendation; stable
+        cardiac estimates will generally require many representative beats.
+
+    Notes
+    -----
+    Public input is converted to ``float32`` or ``float64`` before averaging.
+    Integer and other real numerical dtypes produce ``float64`` output. Input
+    arrays are never modified.
 
     Examples
     --------
-    >>> # ECG artifact removal
+    MNE event arrays use acquisition sample numbering:
+
     >>> from mne.preprocessing import find_ecg_events
     >>> from mne_denoise.dss.denoisers import CycleAverageBias
-    >>> r_peaks, _ = find_ecg_events(raw)  # MNE returns events array
-    >>> # Extract sample indices (column 0)
-    >>> r_peak_samples = r_peaks[:, 0]
-    >>> bias = CycleAverageBias(event_samples=r_peak_samples, window=(-100, 200))
+    >>> ecg_events, _, _ = find_ecg_events(raw)
+    >>> bias = CycleAverageBias(
+    ...     event_samples=ecg_events[:, 0],
+    ...     window=(-0.2, 0.4),
+    ...     window_unit="seconds",
+    ...     sfreq=raw.info["sfreq"],
+    ...     event_origin="raw",
+    ...     first_samp=raw.first_samp,
+    ... )
     >>> biased_data = bias.apply(raw.get_data())
-
-    >>> # EOG (blink) artifact removal
-    >>> from mne.preprocessing import find_eog_events
-    >>> blinks = find_eog_events(raw)
-    >>> blink_samples = blinks[:, 0]
-    >>> bias_eog = CycleAverageBias(event_samples=blink_samples, window=(-200, 200))
-    >>> biased_eog = bias_eog.apply(raw.get_data())
 
     References
     ----------
-    Särelä & Valpola (2005). Section 4.1.4 "DENOISING OF QUASIPERIODIC SIGNALS"
+    Särelä, J., & Valpola, H. (2005). Denoising source separation.
+    Journal of Machine Learning Research, 6, 233-272.
     """
 
     def __init__(
         self,
-        event_samples: Sequence[int],
-        window: tuple[int, int] = (-100, 200),
+        event_samples: Sequence[int] | Sequence[tuple[int, int]],
+        window: tuple[int | float, int | float] = (-100, 200),
         *,
+        window_unit: Literal["samples", "seconds"] = "samples",
         sfreq: float | None = None,
+        event_origin: Literal["data", "raw"] = "data",
+        first_samp: int | None = None,
+        min_events: int = 2,
     ) -> None:
-        self.event_samples = np.asarray(event_samples, dtype=int)
-
-        # Convert window to samples if sfreq provided
-        if sfreq is not None:
-            self.window = (int(window[0] * sfreq), int(window[1] * sfreq))
-        else:
-            self.window = (int(window[0]), int(window[1]))
-
-        self.sfreq = sfreq
+        self.window = resolve_sample_window(
+            window, unit=window_unit, sfreq=sfreq, name="window"
+        )
+        self.window_input = tuple(window)
+        self.window_unit = window_unit
+        self.sfreq = (
+            check_sfreq(sfreq, context="window_unit='seconds'")
+            if sfreq is not None or window_unit == "seconds"
+            else None
+        )
+        self.event_origin = event_origin
+        self.event_samples, self.first_samp, self.event_samples_data_ = _prepare_events(
+            event_samples, event_origin, first_samp
+        )
+        self.min_events = check_positive_integer(min_events, name="min_events")
+        if self.min_events < 2:
+            raise ValueError("min_events must be greater than or equal to 2")
         self._window_length = self.window[1] - self.window[0]
 
     def apply(self, data: np.ndarray) -> np.ndarray:
-        """Apply cycle averaging bias.
+        """Apply fixed-window event-locked averaging.
 
         Parameters
         ----------
         data : ndarray, shape (n_channels, n_times) or (n_channels, n_times, n_epochs)
-            Input data.
+            Continuous or channel-first epoched input.
 
         Returns
         -------
-        biased : ndarray, same shape as input
-            Data where artifact-locked segments are replaced by cycle average.
+        biased : ndarray, same shape as data
+            Floating-point event-locked estimate. Overlapping contributions are
+            averaged sample by sample.
         """
-        original_shape = data.shape
-
-        # Handle 3D epoched data by concatenating
-        if data.ndim == 3:
-            n_channels, n_times, n_epochs = data.shape
-            # Adjust events for concatenated epochs
-            data_2d = data.reshape(n_channels, -1)
-            total_samples = n_times * n_epochs
-        elif data.ndim == 2:
-            data_2d = data
-            n_channels, total_samples = data.shape
-        else:
-            raise ValueError(f"Data must be 2D or 3D, got {data.ndim}D")
-
-        # Filter valid events (within data bounds)
-        pre, post = self.window
-        valid_mask = (self.event_samples + pre >= 0) & (
-            self.event_samples + post <= total_samples
+        data = _as_float_data(data)
+        segments = _event_segments(
+            data, self.event_samples_data_, self.window, self.min_events
         )
-        valid_events = self.event_samples[valid_mask]
+        windows = [data[(slice(None), *segment)] for segment in segments]
+        cycle_average = np.mean(np.stack(windows), axis=0, dtype=data.dtype)
 
-        if len(valid_events) == 0:
-            # No valid events, return zeros (no artifact signal)
-            return np.zeros(original_shape)
-
-        # Compute cycle average
-        window_len = post - pre
-        epochs_matrix = np.zeros((len(valid_events), n_channels, window_len))
-
-        for i, event in enumerate(valid_events):
-            start = event + pre
-            end = event + post
-            epochs_matrix[i] = data_2d[:, start:end]
-
-        # Average across artifact cycles
-        cycle_average = np.mean(epochs_matrix, axis=0)  # (n_channels, window_len)
-
-        # Create biased output: each artifact window gets the average
-        biased_2d = np.zeros_like(data_2d)
-
-        for event in valid_events:
-            start = event + pre
-            end = event + post
-            biased_2d[:, start:end] = cycle_average
-
-        # Reshape back if needed
-        if len(original_shape) == 3:
-            biased = biased_2d.reshape(original_shape)
-        else:
-            biased = biased_2d
-
+        biased = np.zeros_like(data)
+        counts = np.zeros(data.shape[1:], dtype=np.int64)
+        for segment in segments:
+            biased[(slice(None), *segment)] += cycle_average
+            counts[segment] += 1
+        np.divide(
+            biased,
+            counts[np.newaxis, ...],
+            out=biased,
+            where=counts[np.newaxis, ...] > 0,
+        )
         return biased

--- a/mne_denoise/dss/linear.py
+++ b/mne_denoise/dss/linear.py
@@ -527,6 +527,7 @@ class DSS(BaseEstimator, TransformerMixin):
         set_log_level_from_verbose(self.verbose)
         self._mne_ch_names_ = None
         self._validate_component_action()
+        self._validate_decomposition_parameters()
         if not isinstance(self.center, bool):
             raise TypeError("center must be a bool")
         if self.adaptive:
@@ -619,6 +620,23 @@ class DSS(BaseEstimator, TransformerMixin):
                 "component_action must be one of "
                 f"{{{allowed}}}, got {self.component_action!r}."
             )
+
+    def _validate_decomposition_parameters(self) -> None:
+        """Reject nonsensical component, rank, and selection counts early."""
+        if self.n_components is not None and (
+            isinstance(self.n_components, bool)
+            or not isinstance(self.n_components, int | np.integer)
+            or int(self.n_components) <= 0
+        ):
+            raise ValueError("n_components must be a positive integer or None")
+        if isinstance(self.rank, int | np.integer) and (
+            isinstance(self.rank, bool) or int(self.rank) <= 0
+        ):
+            raise ValueError("rank must be a positive integer when specified as an int")
+        if isinstance(self.n_select, int | np.integer) and (
+            isinstance(self.n_select, bool) or int(self.n_select) < 0
+        ):
+            raise ValueError("n_select must be a non-negative integer, 'auto', or None")
 
     def auto_select(self, threshold: float | None = None) -> int:
         """Automatically determine how many DSS components are significant.

--- a/mne_denoise/dss/utils/whitening.py
+++ b/mne_denoise/dss/utils/whitening.py
@@ -130,6 +130,10 @@ def compute_data_covariance_whitener(
         raise TypeError("rank must be an int or None")
     if rank is not None and rank <= 0:
         raise ValueError("rank must be positive")
+    if rank is not None and rank > cov.shape[0]:
+        raise ValueError(
+            f"rank ({rank}) cannot exceed the channel count ({cov.shape[0]})"
+        )
     if isinstance(reg, bool) or not isinstance(reg, Real):
         raise TypeError("reg must be a real number")
     if not np.isfinite(reg) or reg < 0:

--- a/scripts/validate_cardiac_dss.py
+++ b/scripts/validate_cardiac_dss.py
@@ -1,0 +1,696 @@
+"""Validate the explicit CycleAverageBias plus DSS cardiac recipe.
+
+This script is intentionally outside the package unit-test surface. It fits on
+synthetic training events, applies one frozen spatial operator to isolated
+held-out contributions, runs negative controls and sensitivity analyses, and
+writes machine-readable JSON. An optional local FIF pathway provides a
+plausibility check against unchanged data and ECG SSP; it is not evidence of
+universal or clinical superiority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import mne
+import numpy as np
+from mne.preprocessing import compute_proj_ecg, find_ecg_events
+from scipy.signal import resample_poly
+
+from mne_denoise import compute_covariance
+from mne_denoise.dss import DSS, CycleAverageBias, compute_dss
+
+
+def _rms(values):
+    """Return root-mean-square amplitude as a Python float."""
+    return float(np.sqrt(np.mean(np.asarray(values, dtype=float) ** 2)))
+
+
+def _db_ratio(before, after):
+    """Return positive attenuation in decibels."""
+    tiny = np.finfo(float).tiny
+    return float(20 * np.log10(max(_rms(before), tiny) / max(_rms(after), tiny)))
+
+
+def _locked_average(data, events, window):
+    """Average complete half-open windows around data-relative events."""
+    start, stop = window
+    return np.mean(
+        np.stack([data[:, event + start : event + stop] for event in events]), axis=0
+    )
+
+
+def _spectral_power(data, sfreq, frequencies):
+    """Return summed sensor power at the nearest FFT bins."""
+    spectrum = np.fft.rfft(data, axis=1)
+    bins = np.fft.rfftfreq(data.shape[1], 1 / sfreq)
+    powers = {}
+    for frequency in frequencies:
+        index = int(np.argmin(np.abs(bins - frequency)))
+        powers[f"{frequency:.4g}_hz"] = float(np.sum(np.abs(spectrum[:, index]) ** 2))
+    return powers
+
+
+def _waveform_metrics(before, after, sfreq):
+    """Quantify power, correlation, gain, latency, and RMS distortion."""
+    x = np.asarray(before, dtype=float).ravel()
+    y = np.asarray(after, dtype=float).ravel()
+    denominator = float(x @ x)
+    gain = float((x @ y) / denominator) if denominator else 0.0
+    correlation = float(np.corrcoef(x, y)[0, 1]) if np.std(x) and np.std(y) else 0.0
+    relative_rms = _rms(y - x) / max(_rms(x), np.finfo(float).tiny)
+    max_lag = max(1, round(0.05 * sfreq))
+    lag_scores = []
+    for lag in range(-max_lag, max_lag + 1):
+        if lag < 0:
+            left, right = x[-lag:], y[:lag]
+        elif lag > 0:
+            left, right = x[:-lag], y[lag:]
+        else:
+            left, right = x, y
+        lag_scores.append(float(left @ right))
+    latency_samples = int(np.argmax(lag_scores) - max_lag)
+    return {
+        "retained_power": float((y @ y) / denominator) if denominator else 0.0,
+        "waveform_correlation": correlation,
+        "gain": gain,
+        "latency_samples": latency_samples,
+        "latency_ms": float(1_000 * latency_samples / sfreq),
+        "relative_rms_distortion": float(relative_rms),
+    }
+
+
+def _make_events(rng, n_times, sfreq):
+    """Generate complete, jittered heartbeat coordinates."""
+    event = round(0.8 * sfreq)
+    events = []
+    while event < n_times - round(0.5 * sfreq):
+        events.append(event)
+        interval = round(rng.normal(0.8, 0.045) * sfreq)
+        event += max(round(0.55 * sfreq), interval)
+    return np.asarray(events, dtype=int)
+
+
+def _qrs_train(data, events, rng, sfreq, topography):
+    """Add variable-amplitude and slightly variable-width QRS morphology."""
+    artifact = np.zeros_like(data)
+    for event in events:
+        half_width = round(rng.uniform(0.08, 0.11) * sfreq)
+        offsets = np.arange(-half_width, half_width + 1)
+        width = rng.uniform(0.012, 0.018) * sfreq
+        qrs = np.exp(-0.5 * (offsets / width) ** 2)
+        qrs -= 0.35 * np.exp(-0.5 * ((offsets - 0.04 * sfreq) / (1.7 * width)) ** 2)
+        amplitude = rng.lognormal(mean=0.0, sigma=0.12)
+        artifact[:, event - half_width : event + half_width + 1] += (
+            amplitude * topography[:, np.newaxis] * qrs
+        )
+    return artifact
+
+
+def make_synthetic(seed=97, sfreq=200.0, duration=45.0, n_channels=8):
+    """Create isolated train/test cardiac, neural, and noise contributions."""
+    rng = np.random.default_rng(seed)
+    n_times = round(duration * sfreq)
+    heart_frequency = 1.25
+    topography = np.array([8, 5.6, -4, 2.8, -2, 1.2, -0.8, 0.4], dtype=float)[
+        :n_channels
+    ]
+    neural_mix = rng.normal(size=(n_channels, 4))
+
+    def one_split(split_seed):
+        split_rng = np.random.default_rng(split_seed)
+        times = np.arange(n_times) / sfreq
+        events = _make_events(split_rng, n_times, sfreq)
+        cardiac = _qrs_train(
+            np.zeros((n_channels, n_times)), events, split_rng, sfreq, topography
+        )
+        target_sources = np.vstack(
+            [
+                np.sin(2 * np.pi * 10 * times + split_rng.uniform(0, 2 * np.pi)),
+                0.3
+                * np.sin(
+                    2 * np.pi * heart_frequency * times
+                    + split_rng.uniform(0, 2 * np.pi)
+                ),
+            ]
+        )
+        non_target_sources = np.vstack(
+            [
+                0.6 * np.sin(2 * np.pi * 18 * times + 0.3),
+                0.35 * np.sin(2 * np.pi * 3.7 * times + 1.2),
+            ]
+        )
+        target = neural_mix[:, :2] @ target_sources
+        non_target = neural_mix[:, 2:] @ non_target_sources
+        scale = np.std(np.vstack([target, non_target]))
+        target /= scale
+        non_target /= scale
+        noise = 0.08 * split_rng.standard_normal((n_channels, n_times))
+        return {
+            "events": events,
+            "cardiac": cardiac,
+            "target_neural": target,
+            "non_target_neural": non_target,
+            "noise": noise,
+        }
+
+    return {
+        "sfreq": sfreq,
+        "heart_frequency": heart_frequency,
+        "train": one_split(rng.integers(0, 2**32)),
+        "held_out": one_split(rng.integers(0, 2**32)),
+    }
+
+
+def _mixture(split):
+    """Sum all isolated synthetic contributions."""
+    return sum(
+        split[key] for key in ("cardiac", "target_neural", "non_target_neural", "noise")
+    )
+
+
+def _fit(events, data, window, rank, n_components, n_select):
+    """Fit the explicit public fixed-window cardiac composition."""
+    return DSS(
+        bias=CycleAverageBias(
+            events,
+            window,
+            window_unit="samples",
+            event_origin="data",
+        ),
+        rank=rank,
+        n_components=n_components,
+        n_select=n_select,
+        component_action="subtract",
+        normalize_input=False,
+        center=False,
+    ).fit(data)
+
+
+def _evaluate(estimator, held_out, window, sfreq, heart_frequency):
+    """Apply a frozen estimator to each isolated held-out contribution."""
+    mixture = _mixture(held_out)
+    clean = mixture - held_out["cardiac"]
+    transformed = {
+        key: estimator.transform(held_out[key])
+        for key in ("cardiac", "target_neural", "non_target_neural", "noise")
+    }
+    output = estimator.transform(mixture)
+    component_sum = sum(transformed.values())
+    before_locked = _locked_average(mixture, held_out["events"], window)
+    after_locked = _locked_average(output, held_out["events"], window)
+    cardiac_before_locked = _locked_average(
+        held_out["cardiac"], held_out["events"], window
+    )
+    cardiac_after_locked = _locked_average(
+        transformed["cardiac"], held_out["events"], window
+    )
+    harmonic_frequencies = [heart_frequency * multiplier for multiplier in (1, 2, 3)]
+    before_harmonics = _spectral_power(held_out["cardiac"], sfreq, harmonic_frequencies)
+    after_harmonics = _spectral_power(
+        transformed["cardiac"], sfreq, harmonic_frequencies
+    )
+    harmonic_attenuation = {
+        name: float(10 * np.log10(before_harmonics[name] / after_harmonics[name]))
+        for name in before_harmonics
+    }
+    snr_before = 20 * np.log10(_rms(clean) / _rms(held_out["cardiac"]))
+    snr_after = 20 * np.log10(_rms(clean) / _rms(output - clean))
+    return {
+        "cardiac": {
+            "locked_rms_attenuation_db": _db_ratio(
+                cardiac_before_locked, cardiac_after_locked
+            ),
+            "mixture_locked_rms_attenuation_db": _db_ratio(before_locked, after_locked),
+            "locked_peak_to_peak_attenuation_db": _db_ratio(
+                np.ptp(cardiac_before_locked, axis=1),
+                np.ptp(cardiac_after_locked, axis=1),
+            ),
+            "global_rms_attenuation_db": _db_ratio(
+                held_out["cardiac"], transformed["cardiac"]
+            ),
+            "harmonic_attenuation_db": harmonic_attenuation,
+        },
+        "target_neural": _waveform_metrics(
+            held_out["target_neural"], transformed["target_neural"], sfreq
+        ),
+        "non_target_neural": _waveform_metrics(
+            held_out["non_target_neural"], transformed["non_target_neural"], sfreq
+        ),
+        "background_noise": _waveform_metrics(
+            held_out["noise"], transformed["noise"], sfreq
+        ),
+        "total_output": {
+            "relative_rms_error": float(_rms(output - clean) / _rms(clean)),
+            "held_out_snr_before_db": float(snr_before),
+            "held_out_snr_after_db": float(snr_after),
+            "held_out_snr_improvement_db": float(snr_after - snr_before),
+            "isolated_sum_max_abs_error": float(np.max(np.abs(output - component_sum))),
+        },
+    }
+
+
+def _controlled_events(events, n_times, window, rng):
+    """Return shuffled, reversed, and circular event negative controls."""
+    low, high = -window[0], n_times - window[1]
+    shuffled = np.sort(rng.choice(np.arange(low, high + 1), len(events), replace=False))
+    reversed_events = np.sort(n_times - 1 - events)
+    shift = round(0.37 * np.median(np.diff(events)))
+    span = high - low + 1
+    circular = np.sort(low + ((events - low + shift) % span))
+    return {
+        "shuffled_events": shuffled,
+        "time_reversed_events": reversed_events,
+        "circularly_shifted_events": circular,
+    }
+
+
+def run_negative_controls(dataset, window, rank, n_components):
+    """Run event, pure-noise, neural-only, and wrong-origin controls."""
+    train = dataset["train"]
+    held_out = dataset["held_out"]
+    train_mixture = _mixture(train)
+    rng = np.random.default_rng(2025)
+    controls = {}
+    for name, events in _controlled_events(
+        train["events"], train_mixture.shape[1], window, rng
+    ).items():
+        estimator = _fit(events, train_mixture, window, rank, n_components, 1)
+        metrics = _evaluate(
+            estimator,
+            held_out,
+            window,
+            dataset["sfreq"],
+            dataset["heart_frequency"],
+        )
+        controls[name] = {
+            "true_qrs_locked_attenuation_db": metrics["cardiac"][
+                "mixture_locked_rms_attenuation_db"
+            ],
+            "broad_power_retained": float(
+                np.sum(estimator.transform(_mixture(held_out)) ** 2)
+                / np.sum(_mixture(held_out) ** 2)
+            ),
+        }
+
+    neural_train = train["target_neural"] + train["non_target_neural"]
+    neural_test = held_out["target_neural"] + held_out["non_target_neural"]
+    neural_estimator = _fit(
+        train["events"], neural_train, window, rank, n_components, 1
+    )
+    controls["neural_only"] = _waveform_metrics(
+        neural_test, neural_estimator.transform(neural_test), dataset["sfreq"]
+    )
+    noise_estimator = _fit(
+        train["events"], train["noise"], window, rank, n_components, 1
+    )
+    controls["pure_noise"] = _waveform_metrics(
+        held_out["noise"],
+        noise_estimator.transform(held_out["noise"]),
+        dataset["sfreq"],
+    )
+
+    try:
+        wrong = CycleAverageBias(
+            train["events"] + 10_000,
+            window,
+            window_unit="samples",
+            event_origin="data",
+        )
+        wrong.apply(train_mixture)
+    except ValueError as error:
+        controls["wrong_event_origin"] = {
+            "rejected": True,
+            "reason": str(error),
+        }
+    else:  # pragma: no cover - a regression should make this visible in JSON
+        controls["wrong_event_origin"] = {"rejected": False}
+    return controls
+
+
+def run_sensitivity(dataset, base_window, rank, n_components):
+    """Sweep timing, event quality, window, rank, selection, and resampling."""
+    train = dataset["train"]
+    held_out = dataset["held_out"]
+    mixture = _mixture(train)
+    rng = np.random.default_rng(404)
+    cases = []
+
+    def evaluate_case(name, events, window, case_rank, case_components, n_select):
+        estimator = _fit(events, mixture, window, case_rank, case_components, n_select)
+        metrics = _evaluate(
+            estimator,
+            held_out,
+            base_window,
+            dataset["sfreq"],
+            dataset["heart_frequency"],
+        )
+        cases.append(
+            {
+                "case": name,
+                "event_count": len(events),
+                "window": list(window),
+                "rank": case_rank,
+                "n_select": n_select,
+                "cardiac_locked_attenuation_db": metrics["cardiac"][
+                    "locked_rms_attenuation_db"
+                ],
+                "target_retained_power": metrics["target_neural"]["retained_power"],
+                "target_correlation": metrics["target_neural"]["waveform_correlation"],
+            }
+        )
+
+    events = train["events"]
+    evaluate_case("baseline", events, base_window, rank, n_components, 1)
+    for jitter in (1, 3, 6, 12):
+        jittered = np.sort(events + rng.integers(-jitter, jitter + 1, len(events)))
+        evaluate_case(
+            f"event_jitter_{jitter}_samples",
+            jittered,
+            base_window,
+            rank,
+            n_components,
+            1,
+        )
+    evaluate_case(
+        "duplicate_25_percent",
+        events[::4].tolist() + events.tolist(),
+        base_window,
+        rank,
+        n_components,
+        1,
+    )
+    missed = np.delete(events, np.arange(0, len(events), 4))
+    evaluate_case(
+        "missed_25_percent_unique", missed, base_window, rank, n_components, 1
+    )
+    false_events = _controlled_events(events, mixture.shape[1], base_window, rng)[
+        "shuffled_events"
+    ][: max(2, len(events) // 4)]
+    evaluate_case(
+        "false_25_percent",
+        np.unique(np.concatenate([events, false_events])),
+        base_window,
+        rank,
+        n_components,
+        1,
+    )
+    for seconds in ((-0.1, 0.2), (-0.15, 0.25), (-0.25, 0.4)):
+        window = tuple(round(value * dataset["sfreq"]) for value in seconds)
+        evaluate_case(
+            f"window_{seconds[0]}_{seconds[1]}_s", events, window, rank, n_components, 1
+        )
+    for case_rank in (max(2, rank // 2), rank):
+        for n_select in (1, 2):
+            evaluate_case(
+                f"rank_{case_rank}_select_{n_select}",
+                events,
+                base_window,
+                case_rank,
+                min(n_components, case_rank),
+                n_select,
+            )
+
+    # Resampling is evaluated separately because every isolated contribution
+    # and coordinate must use the same new sampling grid.
+    new_sfreq = dataset["sfreq"] / 2
+    resampled = {"sfreq": new_sfreq, "heart_frequency": dataset["heart_frequency"]}
+    for split_name in ("train", "held_out"):
+        source = dataset[split_name]
+        split = {
+            key: resample_poly(source[key], 1, 2, axis=1)
+            for key in ("cardiac", "target_neural", "non_target_neural", "noise")
+        }
+        split["events"] = np.unique(np.rint(source["events"] / 2).astype(int))
+        resampled[split_name] = split
+    resampled_window = tuple(round(value / 2) for value in base_window)
+    resampled_estimator = _fit(
+        resampled["train"]["events"],
+        _mixture(resampled["train"]),
+        resampled_window,
+        rank,
+        n_components,
+        1,
+    )
+    metrics = _evaluate(
+        resampled_estimator,
+        resampled["held_out"],
+        resampled_window,
+        new_sfreq,
+        resampled["heart_frequency"],
+    )
+    cases.append(
+        {
+            "case": "resampled_100_hz",
+            "event_count": len(resampled["train"]["events"]),
+            "window": list(resampled_window),
+            "rank": rank,
+            "n_select": 1,
+            "cardiac_locked_attenuation_db": metrics["cardiac"][
+                "locked_rms_attenuation_db"
+            ],
+            "target_retained_power": metrics["target_neural"]["retained_power"],
+            "target_correlation": metrics["target_neural"]["waveform_correlation"],
+        }
+    )
+    return cases
+
+
+def _source_parity(estimator, train_data):
+    """Compare the fitted composition with its public numerical constituents."""
+    biased = estimator.bias.apply(train_data)
+    filters, patterns, eigenvalues = compute_dss(
+        compute_covariance(train_data, assume_centered=True),
+        compute_covariance(biased, assume_centered=True),
+        n_components=estimator.n_components,
+        rank=estimator.rank,
+        reg=estimator.reg,
+    )
+    expected = train_data - patterns[:, :1] @ filters[:1] @ train_data
+    return {
+        "filters_max_abs_error": float(np.max(np.abs(estimator.filters_ - filters))),
+        "patterns_max_abs_error": float(np.max(np.abs(estimator.patterns_ - patterns))),
+        "eigenvalues_max_abs_error": float(
+            np.max(np.abs(estimator.eigenvalues_ - eigenvalues))
+        ),
+        "output_max_abs_error": float(
+            np.max(np.abs(estimator.transform(train_data) - expected))
+        ),
+    }
+
+
+def run_real_data(raw_fif, ecg_channel, duration):
+    """Run an optional local-recording plausibility check and ECG SSP comparator."""
+    raw = mne.io.read_raw_fif(raw_fif, preload=True, verbose=False)
+    if duration is not None:
+        raw.crop(tmax=min(duration, raw.times[-1]))
+    events, _, _ = find_ecg_events(raw, ch_name=ecg_channel, verbose=False)
+    midpoint = raw.times[-1] / 2
+    train_all = raw.copy().crop(tmax=midpoint, include_tmax=False)
+    held_all = raw.copy().crop(tmin=midpoint)
+    train_events = events[
+        (events[:, 0] >= train_all.first_samp) & (events[:, 0] <= train_all.last_samp)
+    ]
+    held_events = events[
+        (events[:, 0] >= held_all.first_samp) & (events[:, 0] <= held_all.last_samp)
+    ]
+    if min(len(train_events), len(held_events)) < 2:
+        raise ValueError(
+            "real-data split requires at least two ECG events in each half"
+        )
+
+    picks = mne.pick_types(raw.info, eeg=True, meg=False, exclude="bads")
+    sensor_type = "eeg"
+    if len(picks) < 2:
+        picks = mne.pick_types(raw.info, meg="grad", eeg=False, exclude="bads")
+        sensor_type = "grad"
+    if len(picks) < 2:
+        picks = mne.pick_types(raw.info, meg="mag", eeg=False, exclude="bads")
+        sensor_type = "mag"
+    if len(picks) < 2:
+        raise ValueError(
+            "real-data check requires at least two good EEG or MEG channels"
+        )
+    train = train_all.copy().pick(picks)
+    held = held_all.copy().pick(picks)
+    sfreq = float(raw.info["sfreq"])
+    window = (-round(0.2 * sfreq), round(0.4 * sfreq))
+    rank = min(len(train.ch_names), 20)
+    estimator = DSS(
+        bias=CycleAverageBias(
+            train_events[:, 0],
+            window,
+            event_origin="raw",
+            first_samp=train.first_samp,
+        ),
+        rank={sensor_type: rank},
+        n_components=rank,
+        n_select=1,
+        component_action="subtract",
+        normalize_input=False,
+    ).fit(train)
+    cleaned = estimator.transform(held)
+    held_relative_events = held_events[:, 0] - held.first_samp
+    unchanged_locked = _locked_average(held.get_data(), held_relative_events, window)
+    cleaned_locked = _locked_average(cleaned.get_data(), held_relative_events, window)
+    result = {
+        "dataset": str(Path(raw_fif).resolve()),
+        "preprocessing": "preloaded; first half fit; second half held out; good homogeneous sensors; no filtering added by this script",
+        "sensor_type": sensor_type,
+        "n_channels": len(train.ch_names),
+        "train_event_count": len(train_events),
+        "held_out_event_count": len(held_events),
+        "unchanged_locked_rms": _rms(unchanged_locked),
+        "cardiac_dss_locked_rms": _rms(cleaned_locked),
+        "cardiac_dss_attenuation_db": _db_ratio(unchanged_locked, cleaned_locked),
+        "cardiac_dss_broad_power_retained": float(
+            np.sum(cleaned.get_data() ** 2) / np.sum(held.get_data() ** 2)
+        ),
+    }
+    try:
+        projections, _ = compute_proj_ecg(
+            train_all,
+            ch_name=ecg_channel,
+            n_grad=1,
+            n_mag=1,
+            n_eeg=1,
+            verbose=False,
+        )
+        ssp = held_all.copy().add_proj(projections).apply_proj().pick(picks)
+        ssp_locked = _locked_average(ssp.get_data(), held_relative_events, window)
+        result["ecg_ssp"] = {
+            "locked_rms": _rms(ssp_locked),
+            "attenuation_db": _db_ratio(unchanged_locked, ssp_locked),
+            "broad_power_retained": float(
+                np.sum(ssp.get_data() ** 2) / np.sum(held.get_data() ** 2)
+            ),
+        }
+    except Exception as error:  # comparator availability varies by recording
+        result["ecg_ssp"] = {"available": False, "reason": str(error)}
+    return result
+
+
+def main():
+    """Run validation and write deterministic JSON metrics."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("cardiac_dss_validation.json"),
+        help="JSON metrics path.",
+    )
+    parser.add_argument("--real-raw-fif", type=Path, default=None)
+    parser.add_argument("--ecg-channel", default=None)
+    parser.add_argument("--real-duration", type=float, default=120.0)
+    args = parser.parse_args()
+
+    dataset = make_synthetic()
+    sfreq = dataset["sfreq"]
+    window = (-round(0.15 * sfreq), round(0.25 * sfreq))
+    rank = _mixture(dataset["train"]).shape[0]
+    n_components = min(6, rank)
+    estimator = _fit(
+        dataset["train"]["events"],
+        _mixture(dataset["train"]),
+        window,
+        rank,
+        n_components,
+        1,
+    )
+    positive = _evaluate(
+        estimator,
+        dataset["held_out"],
+        window,
+        sfreq,
+        dataset["heart_frequency"],
+    )
+    negative = run_negative_controls(dataset, window, rank, n_components)
+    sensitivity = run_sensitivity(dataset, window, rank, n_components)
+    parity = _source_parity(estimator, _mixture(dataset["train"]))
+
+    gates = {
+        "cardiac_locked_attenuation_at_least_6_db": positive["cardiac"][
+            "locked_rms_attenuation_db"
+        ]
+        >= 6,
+        "target_retained_power_between_0_8_and_1_2": 0.8
+        <= positive["target_neural"]["retained_power"]
+        <= 1.2,
+        "target_waveform_correlation_at_least_0_95": positive["target_neural"][
+            "waveform_correlation"
+        ]
+        >= 0.95,
+        "non_target_retained_power_at_least_0_85": positive["non_target_neural"][
+            "retained_power"
+        ]
+        >= 0.85,
+        "held_out_snr_improvement_at_least_3_db": positive["total_output"][
+            "held_out_snr_improvement_db"
+        ]
+        >= 3,
+        "pure_noise_retained_power_at_least_0_8": negative["pure_noise"][
+            "retained_power"
+        ]
+        >= 0.8,
+        "neural_only_retained_power_at_least_0_8": negative["neural_only"][
+            "retained_power"
+        ]
+        >= 0.8,
+        "wrong_origin_rejected": negative["wrong_event_origin"]["rejected"],
+        "public_operation_parity_below_1e_12": max(parity.values()) < 1e-12,
+    }
+    positive_locked = positive["cardiac"]["mixture_locked_rms_attenuation_db"]
+    for control_name in (
+        "shuffled_events",
+        "time_reversed_events",
+        "circularly_shifted_events",
+    ):
+        gates[f"{control_name}_at_least_6_db_below_positive"] = (
+            negative[control_name]["true_qrs_locked_attenuation_db"]
+            <= positive_locked - 6
+        )
+    gates["all_passed"] = all(gates.values())
+    result = {
+        "schema_version": 1,
+        "method": "CycleAverageBias fixed-window composition with DSS subtraction",
+        "seed": 97,
+        "synthetic_design": {
+            "sfreq": sfreq,
+            "duration_per_split_seconds": 45.0,
+            "train_event_count": len(dataset["train"]["events"]),
+            "held_out_event_count": len(dataset["held_out"]["events"]),
+            "window_samples": list(window),
+            "rank": rank,
+            "n_components": n_components,
+            "n_select": 1,
+        },
+        "source_parity": parity,
+        "positive_control": positive,
+        "negative_controls": negative,
+        "sensitivity": sensitivity,
+        "predeclared_gates": gates,
+    }
+    if args.real_raw_fif is not None:
+        if args.ecg_channel is None:
+            parser.error("--ecg-channel is required with --real-raw-fif")
+        result["real_data"] = run_real_data(
+            args.real_raw_fif, args.ecg_channel, args.real_duration
+        )
+    else:
+        result["real_data"] = {
+            "status": "not_run",
+            "reason": "Pass --real-raw-fif and --ecg-channel for an optional local-recording plausibility check.",
+        }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(gates, indent=2, sort_keys=True))
+    print(f"Wrote {args.output}")
+    if not gates["all_passed"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/denoisers/test_artifact.py
+++ b/tests/denoisers/test_artifact.py
@@ -1,143 +1,274 @@
-"""Unit tests for artifact denoisers (CycleAverageBias)."""
+"""Adversarial contract tests for :class:`CycleAverageBias`."""
+
+from __future__ import annotations
 
 import numpy as np
-from numpy.testing import assert_allclose
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
 
 from mne_denoise.dss.denoisers.artifact import CycleAverageBias
 
 
-def test_cycle_average_bias():
-    """Test CycleAverageBias on synthetic data."""
-    rng = np.random.default_rng(42)
-    n_channels = 3
-    n_times = 1000
-
-    # 1. Create synthetic periodic artifact (e.g., heartbeat)
-    events = np.arange(100, n_times - 100, 200)
-    artifact_signal = np.zeros(n_times)
-
-    template_len = 50
-    template = np.hanning(template_len)
-
-    for event in events:
-        start = event - template_len // 2
-        end = start + template_len
-        if start >= 0 and end <= n_times:
-            artifact_signal[start:end] += template
-
-    artifact_data = np.outer([1.0, 0.5, -0.5], artifact_signal)
-
-    # 2. Add asynchronous noise (simulated brain activity)
-    noise = rng.normal(0, 0.1, (n_channels, n_times))
-    data = artifact_data + noise
-
-    # 3. Apply CycleAverageBias
-    window = (-25, 25)
-    bias = CycleAverageBias(event_samples=events, window=window)
-    biased_data = bias.apply(data)
-
-    # 4. Verification
-    mask = np.ones(n_times, dtype=bool)
-    for event in events:
-        mask[event + window[0] : event + window[1]] = False
-
-    assert_allclose(
-        biased_data[:, mask],
-        0,
-        atol=1e-10,
-        err_msg="Biased data should be zero outside windows",
+def _bias(events, window=(-2, 3), **kwargs):
+    """Construct a concise data-relative sample-window bias."""
+    return CycleAverageBias(
+        event_samples=events,
+        window=window,
+        window_unit="samples",
+        event_origin="data",
+        **kwargs,
     )
 
-    # Extract one window from biased data
-    event = events[0]
-    biased_epoch = biased_data[:, event + window[0] : event + window[1]]
 
-    # Theoretical clean epoch
-    clean_epoch = artifact_data[:, event + window[0] : event + window[1]]
+def test_cycle_average_estimates_repeated_morphology_without_mutation():
+    """The fixed-window estimate preserves shape and leaves input untouched."""
+    rng = np.random.default_rng(42)
+    events = np.arange(100, 900, 200)
+    template = np.hanning(50)
+    artifact = np.zeros(1_000)
+    for event in events:
+        artifact[event - 25 : event + 25] = template
+    clean = np.outer([1.0, 0.5, -0.5], artifact)
+    data = clean + rng.normal(0, 0.1, clean.shape)
+    original = data.copy()
 
-    # Correlation should be high
-    corr = np.corrcoef(biased_epoch.ravel(), clean_epoch.ravel())[0, 1]
-    assert corr > 0.95, (
-        f"Biased data should correlate with clean artifact (got {corr:.3f})"
+    observed = _bias(events, window=(-25, 25)).apply(data)
+
+    mask = np.ones(data.shape[1], dtype=bool)
+    for event in events:
+        mask[event - 25 : event + 25] = False
+    assert_allclose(observed[:, mask], 0)
+    assert (
+        np.corrcoef(observed[:, 75:125].ravel(), clean[:, 75:125].ravel())[0, 1] > 0.95
+    )
+    assert observed.shape == data.shape
+    assert_array_equal(data, original)
+    assert not np.shares_memory(observed, data)
+
+
+def test_cycle_average_seconds_have_explicit_nearest_sample_contract():
+    """Second boundaries are converted once with ties-to-even rounding."""
+    bias = CycleAverageBias(
+        event_samples=[20, 40],
+        window=(-0.015, 0.025),
+        window_unit="seconds",
+        sfreq=100.0,
+        event_origin="data",
     )
 
-    # Check shape preservation
-    assert biased_data.shape == data.shape
+    assert bias.window_input == (-0.015, 0.025)
+    assert bias.window == (-2, 2)
 
 
-def test_cycle_average_bias_sfreq():
-    """Test CycleAverageBias with second-based window."""
-    events = [100, 200]
-    sfreq = 100.0
+def test_cycle_average_epoch_coordinates_never_join_epochs():
+    """Per-epoch extraction cannot borrow samples from a neighboring epoch."""
+    data = np.zeros((1, 6, 2))
+    data[0, :, 0] = np.arange(1.0, 7.0)
+    data[0, :, 1] = np.arange(101.0, 107.0)
+    bias = _bias([[0, 2], [1, 2]], window=(-1, 2))
 
-    # Window: -0.1s to +0.2s -> -10 to +20 samples
-    bias = CycleAverageBias(event_samples=events, window=(-0.1, 0.2), sfreq=sfreq)
+    observed = bias.apply(data)
 
-    assert bias.window == (-10, 20)
-
-
-def test_cycle_average_bias_3d_data():
-    """Test CycleAverageBias with 3D epoched data."""
-    rng = np.random.default_rng(42)
-    n_channels, n_times, n_epochs = 3, 100, 5
-
-    # Create 3D data
-    data = rng.normal(0, 1, (n_channels, n_times, n_epochs))
-
-    # Add a periodic artifact at known locations
-    events = np.array([20, 50, 80])  # Within first epoch
-
-    bias = CycleAverageBias(event_samples=events, window=(-5, 5))
-    biased = bias.apply(data)
-
-    # Output should be 3D with same shape
-    assert biased.shape == data.shape
-    assert biased.ndim == 3
+    expected_template = np.array([52.0, 53.0, 54.0])
+    assert_allclose(observed[0, 1:4, 0], expected_template)
+    assert_allclose(observed[0, 1:4, 1], expected_template)
+    assert_allclose(observed[0, [0, 4, 5], :], 0)
 
 
-def test_cycle_average_bias_empty_events():
-    """Test CycleAverageBias with no valid events returns zeros."""
-    rng = np.random.default_rng(42)
-    n_channels, n_times = 3, 100
-    data = rng.normal(0, 1, (n_channels, n_times))
+def test_cycle_average_rejects_flat_coordinates_for_epochs():
+    """The stale global-index API cannot silently flatten independent epochs."""
+    data = np.ones((2, 10, 2))
 
-    # Events outside data bounds
-    events = np.array([1000, 2000])  # Way outside
-
-    bias = CycleAverageBias(event_samples=events, window=(-10, 10))
-    biased = bias.apply(data)
-
-    # Should return zeros when no valid events
-    assert_allclose(biased, 0)
-    assert biased.shape == data.shape
+    with pytest.raises(ValueError, match="requires .*epoch_index, sample_index"):
+        _bias([8, 10], window=(-1, 2)).apply(data)
 
 
-def test_cycle_average_bias_invalid_ndim():
-    """Test CycleAverageBias raises error for invalid dimensions."""
-    import pytest
-
-    events = [50]
-    bias = CycleAverageBias(event_samples=events, window=(-5, 5))
-
-    # 1D data should raise ValueError
-    data_1d = np.array([1, 2, 3, 4, 5])
-    with pytest.raises(ValueError, match="Data must be 2D or 3D"):
-        bias.apply(data_1d)
+def test_cycle_average_rejects_epoch_coordinates_for_continuous_data():
+    """Coordinate dimensionality must match the data dimensionality."""
+    with pytest.raises(ValueError, match="2-D data requires one-dimensional"):
+        _bias([[0, 4], [1, 4]], window=(-1, 2)).apply(np.ones((2, 10)))
 
 
-def test_cycle_average_bias_partial_valid_events():
-    """Test CycleAverageBias handles mix of valid and invalid events."""
-    rng = np.random.default_rng(42)
-    n_channels, n_times = 2, 200
-    data = rng.normal(0, 1, (n_channels, n_times))
+def test_overlapping_events_are_permutation_invariant_and_commutative():
+    """Overlaps average shifted contributions instead of last-write winning."""
+    data = np.arange(12.0)[np.newaxis, :]
+    forward = _bias([4, 6], window=(-2, 3)).apply(data)
+    reverse = _bias([6, 4], window=(-2, 3)).apply(data)
 
-    # Mix of valid and invalid events (some at edges)
-    events = np.array([5, 50, 100, 195])  # 5 and 195 may be clipped by window
+    template = (data[:, 2:7] + data[:, 4:9]) / 2
+    expected = np.zeros_like(data)
+    counts = np.zeros(data.shape[1])
+    for event in (4, 6):
+        expected[:, event - 2 : event + 3] += template
+        counts[event - 2 : event + 3] += 1
+    expected /= np.where(counts == 0, 1, counts)
 
-    bias = CycleAverageBias(event_samples=events, window=(-10, 10))
-    biased = bias.apply(data)
+    assert_array_equal(forward, reverse)
+    assert_allclose(forward, expected)
 
-    # Should still work with the valid events in the middle
-    assert biased.shape == data.shape
-    # Middle event (50) window should be non-zero
-    assert np.any(biased[:, 40:60] != 0)
+
+def test_duplicate_events_are_deduplicated_deterministically():
+    """Duplicates neither reweight the template nor satisfy event count."""
+    data = np.arange(20.0)[np.newaxis, :]
+    unique = _bias([5, 12]).apply(data)
+    duplicated = _bias([12, 5, 5, 12]).apply(data)
+
+    assert_array_equal(duplicated, unique)
+    assert duplicated.dtype == np.float64
+    with pytest.raises(ValueError, match="received 1 after deduplication"):
+        _bias([5, 5]).apply(data)
+
+
+@pytest.mark.parametrize("events", [[], [5]])
+def test_cycle_average_requires_multiple_unique_events(events):
+    """Empty and one-event inputs cannot define an event repeatability bias."""
+    with pytest.raises(ValueError, match="at least 2 unique complete events"):
+        _bias(events).apply(np.ones((2, 20)))
+
+
+def test_configured_minimum_may_be_stricter_but_never_one():
+    """The public minimum is explicit and cannot erase repeatability."""
+    with pytest.raises(ValueError, match="greater than or equal to 2"):
+        _bias([5, 10], min_events=1)
+    with pytest.raises(ValueError, match="at least 3"):
+        _bias([5, 10], min_events=3).apply(np.ones((1, 20)))
+
+
+def test_integer_input_is_floating_and_never_truncates_cycle_average():
+    """A half-integer template survives integer public input."""
+    data = np.zeros((1, 8), dtype=np.int16)
+    data[:, 1:3] = [0, 1]
+    data[:, 5:7] = [1, 2]
+
+    observed = _bias([1, 5], window=(0, 2)).apply(data)
+
+    assert observed.dtype == np.float64
+    assert_allclose(observed[:, 1:3], [[0.5, 1.5]])
+    assert_allclose(observed[:, 5:7], [[0.5, 1.5]])
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_supported_float_dtype_is_preserved(dtype):
+    """The supported float pathways retain numerical precision contracts."""
+    data = np.arange(20, dtype=dtype)[np.newaxis, :]
+
+    observed = _bias([5, 12]).apply(data)
+
+    assert observed.dtype == dtype
+
+
+@pytest.mark.parametrize(
+    ("events", "match"),
+    [
+        ([1.5, 4], "integer coordinates"),
+        ([True, 4], "integer coordinates"),
+        ([[0, 1, 2], [1, 2, 3]], r"shape \(n_events, 2\)"),
+        ([2**63, 4], "signed 64-bit"),
+        ([-(2**63) - 1, 4], "signed 64-bit"),
+    ],
+)
+def test_cycle_average_rejects_invalid_event_coordinates(events, match):
+    """Coordinates cannot truncate, wrap, or use an ambiguous shape."""
+    with pytest.raises(ValueError, match=match):
+        _bias(events)
+
+
+@pytest.mark.parametrize(
+    ("window", "unit", "sfreq", "match"),
+    [
+        ((-1.5, 2), "samples", None, "must be integers"),
+        ((2, -1), "samples", None, "strictly less"),
+        ((0, 0.001), "seconds", 100.0, "empty or reversed"),
+        ((-1, 2), "seconds", None, "sfreq is required"),
+        ((-1, 2), "minutes", None, "window_unit"),
+        ((-(2**63) - 1, 2), "samples", None, "signed 64-bit"),
+        ((-1e308, 1e308), "seconds", 1e308, "finite sample range"),
+    ],
+)
+def test_cycle_average_rejects_invalid_window_contracts(window, unit, sfreq, match):
+    """Window conversion fails before unsafe sample arithmetic."""
+    with pytest.raises(ValueError, match=match):
+        CycleAverageBias(
+            [5, 10],
+            window,
+            window_unit=unit,
+            sfreq=sfreq,
+            event_origin="data",
+        )
+
+
+def test_out_of_range_and_boundary_crossing_windows_are_actionable():
+    """No event is silently filtered when its complete window is unavailable."""
+    data = np.ones((2, 20))
+    with pytest.raises(ValueError, match=r"event sample 1.*\[-1, 4\).*boundary"):
+        _bias([1, 10]).apply(data)
+    with pytest.raises(ValueError, match=r"event sample 19.*\[17, 22\).*boundary"):
+        _bias([5, 19]).apply(data)
+    with pytest.raises(ValueError, match="out of range for data with 2 epochs"):
+        _bias([[0, 5], [2, 5]]).apply(np.ones((2, 20, 2)))
+
+
+@pytest.mark.parametrize(
+    ("events", "window"),
+    [([-1, 10], (1, 3)), ([5, 20], (-3, -1))],
+)
+def test_event_itself_must_be_in_range_even_if_offset_window_would_fit(events, window):
+    """An inward-offset window cannot legitimize an invalid event coordinate."""
+    with pytest.raises(ValueError, match=r"out of range.*\[0, 20\)"):
+        _bias(events, window=window).apply(np.ones((2, 20)))
+
+
+def test_exact_boundary_windows_are_valid():
+    """The half-open convention admits a stop exactly at n_times."""
+    data = np.arange(20.0)[np.newaxis, :]
+
+    observed = _bias([2, 17]).apply(data)
+
+    assert np.count_nonzero(observed[:, :5]) > 0
+    assert np.count_nonzero(observed[:, 15:]) > 0
+
+
+def test_raw_origin_subtracts_nonzero_first_samp_exactly_once():
+    """MNE acquisition event samples map into Raw data coordinates."""
+    data = np.arange(40.0)[np.newaxis, :]
+    bias = CycleAverageBias(
+        event_samples=[1_010, 1_020],
+        window=(-2, 3),
+        window_unit="samples",
+        event_origin="raw",
+        first_samp=1_000,
+    )
+
+    first = bias.apply(data)
+    second = bias.apply(data)
+
+    assert bias.event_samples.tolist() == [1010, 1020]
+    assert bias.event_samples_data_.tolist() == [10, 20]
+    assert_array_equal(first, second)
+
+
+def test_event_origin_contract_rejects_ambiguous_offsets_and_overflow():
+    """The Raw offset is required, exclusive, and overflow-safe."""
+    with pytest.raises(ValueError, match="first_samp is required"):
+        CycleAverageBias([10, 20], event_origin="raw")
+    with pytest.raises(ValueError, match="must be omitted"):
+        CycleAverageBias([10, 20], event_origin="data", first_samp=1)
+    with pytest.raises(ValueError, match="not defined for per-epoch"):
+        CycleAverageBias([[0, 5], [1, 5]], event_origin="raw", first_samp=0)
+    with pytest.raises(ValueError, match="signed 64-bit"):
+        CycleAverageBias([np.iinfo(np.int64).min, 1], event_origin="raw", first_samp=1)
+
+
+@pytest.mark.parametrize(
+    ("data", "error", "match"),
+    [
+        (np.ones(10), ValueError, "2D or 3D"),
+        (np.array([["x", "y"]]), TypeError, "real numerical"),
+        (np.ones((1, 10), dtype=complex), TypeError, "real-valued"),
+        (np.array([[1.0, np.nan] * 5]), ValueError, "finite values"),
+    ],
+)
+def test_cycle_average_validates_public_numerical_input(data, error, match):
+    """Unsupported dimensionality, dtype, and nonfinite values fail clearly."""
+    with pytest.raises(error, match=match):
+        _bias([2, 7], window=(-1, 2)).apply(data)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -10,6 +10,7 @@ from mne_denoise._validation import (
     check_channel_layout,
     check_chunk_size,
     check_sfreq,
+    resolve_sample_window,
     resolve_sfreq,
 )
 
@@ -118,6 +119,38 @@ def test_rejects_non_positive_or_non_finite(value):
     """A sampling frequency must be finite and strictly positive."""
     with pytest.raises(ValueError, match="sfreq must be a positive, finite number"):
         check_sfreq(value)
+
+
+# ---------------------------------------------------------------------------
+# resolve_sample_window
+# ---------------------------------------------------------------------------
+
+
+def test_sample_window_resolves_samples_and_seconds():
+    """Both explicit units use one shared half-open conversion contract."""
+    assert resolve_sample_window((-2, 3), unit="samples") == (-2, 3)
+    assert resolve_sample_window((-0.015, 0.025), unit="seconds", sfreq=100.0) == (
+        -2,
+        2,
+    )
+
+
+@pytest.mark.parametrize(
+    ("window", "unit", "sfreq", "match"),
+    [
+        ((-1.5, 2), "samples", None, "must be integers"),
+        ((2, -1), "samples", None, "strictly less"),
+        ((0, 0.001), "seconds", 100.0, "empty or reversed"),
+        ((-1, 2), "seconds", None, "sfreq is required"),
+        ((-1, 2), "minutes", None, "window_unit"),
+        ((-(2**63) - 1, 2), "samples", None, "signed 64-bit"),
+        ((-1e308, 1e308), "seconds", 1e308, "finite sample range"),
+    ],
+)
+def test_sample_window_rejects_invalid_contracts(window, unit, sfreq, match):
+    """Invalid windows fail consistently at the shared package boundary."""
+    with pytest.raises((TypeError, ValueError), match=match):
+        resolve_sample_window(window, unit=unit, sfreq=sfreq)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
  ## Summary

  - harden `CycleAverageBias` event, window, epoch, overlap, dtype, and origin contracts instead of adding a specific cardiacDSS denoiser. 
  - document cardiac cleaning as an explicit composition of MNE ECG detection, `CycleAverageBias`, and subtractive `DSS`
  - add a held-out cardiac-cleaning gallery example using package visualization helpers. 
  - add standalone scientific validation with preservation metrics, sensitivity analyses, and negative controls
  - validate decomposition rank and selection parameters earlier

  This replaces the experimental `CardiacDSS` façade from #60 with the existing canonical DSS implementation and reusable public primitives.

  ## Validation

  - full pytest suite passed
  - Ruff lint and formatting passed
  - focused denoiser and DSS operation tests: 59 passed
  - deterministic cardiac scientific-validation gates passed

a cleaner version of #60 without the evoked history and based on recent updates to the package. 